### PR TITLE
build: Use POSIX 1003.1-2001 tar archives for `make dist`

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,6 +1,5 @@
 # Makefile.am for the SDL truetype font loading library and viewer
 ACLOCAL_AMFLAGS = -I acinclude
-AUTOMAKE_OPTIONS= foreign subdir-objects
 
 lib_LTLIBRARIES = libSDL2_ttf.la
 

--- a/configure.ac
+++ b/configure.ac
@@ -45,7 +45,7 @@ dnl Detect the canonical build and host environments
 AC_CANONICAL_HOST
 
 dnl Setup for automake
-AM_INIT_AUTOMAKE([foreign subdir-objects])
+AM_INIT_AUTOMAKE([foreign subdir-objects tar-pax])
 
 dnl Check for tools
 AC_PROG_CC

--- a/configure.ac
+++ b/configure.ac
@@ -45,7 +45,7 @@ dnl Detect the canonical build and host environments
 AC_CANONICAL_HOST
 
 dnl Setup for automake
-AM_INIT_AUTOMAKE
+AM_INIT_AUTOMAKE([foreign subdir-objects])
 
 dnl Check for tools
 AC_PROG_CC

--- a/configure.ac
+++ b/configure.ac
@@ -1,31 +1,32 @@
 dnl Process this file with autoconf to produce a configure script.
-AC_INIT
+
+dnl Set various version strings - taken gratefully from the GTk sources
+# Making releases:
+#   MICRO_VERSION_MACRO += 1;
+#   INTERFACE_AGE_MACRO += 1;
+#   BINARY_AGE_MACRO += 1;
+# if any functions have been added, set INTERFACE_AGE_MACRO to 0.
+# if backwards compatibility has been broken,
+# set BINARY_AGE_MACRO and INTERFACE_AGE_MACRO to 0.
+m4_define([MAJOR_VERSION_MACRO], [2])
+m4_define([MINOR_VERSION_MACRO], [0])
+m4_define([MICRO_VERSION_MACRO], [15])
+m4_define([INTERFACE_AGE_MACRO], [1])
+m4_define([BINARY_AGE_MACRO], [15])
+
+AC_INIT([SDL2_ttf],
+        MAJOR_VERSION_MACRO.MINOR_VERSION_MACRO.MICRO_VERSION_MACRO,
+        [https://github.com/libsdl-org/SDL_ttf/issues],
+        [SDL2_ttf])
 AC_CONFIG_MACRO_DIR([acinclude])
 AC_CONFIG_SRCDIR([SDL_ttf.c])
 
-dnl Set various version strings - taken gratefully from the GTk sources
-
-# Making releases:
-#   MICRO_VERSION += 1;
-#   INTERFACE_AGE += 1;
-#   BINARY_AGE += 1;
-# if any functions have been added, set INTERFACE_AGE to 0.
-# if backwards compatibility has been broken,
-# set BINARY_AGE and INTERFACE_AGE to 0.
-
-MAJOR_VERSION=2
-MINOR_VERSION=0
-MICRO_VERSION=15
-INTERFACE_AGE=1
-BINARY_AGE=15
-VERSION=$MAJOR_VERSION.$MINOR_VERSION.$MICRO_VERSION
-
-AC_SUBST(MAJOR_VERSION)
-AC_SUBST(MINOR_VERSION)
-AC_SUBST(MICRO_VERSION)
-AC_SUBST(INTERFACE_AGE)
-AC_SUBST(BINARY_AGE)
-AC_SUBST(VERSION)
+AC_SUBST([MAJOR_VERSION], MAJOR_VERSION_MACRO)
+AC_SUBST([MINOR_VERSION], MINOR_VERSION_MACRO)
+AC_SUBST([MICRO_VERSION], MICRO_VERSION_MACRO)
+AC_SUBST([INTERFACE_AGE], INTERFACE_AGE_MACRO)
+AC_SUBST([BINARY_AGE], BINARY_AGE_MACRO)
+# VERSION is AC_SUBST'd by AC_INIT
 
 # libtool versioning
 LT_INIT([win32-dll])
@@ -44,7 +45,7 @@ dnl Detect the canonical build and host environments
 AC_CANONICAL_HOST
 
 dnl Setup for automake
-AM_INIT_AUTOMAKE(SDL2_ttf, $VERSION)
+AM_INIT_AUTOMAKE
 
 dnl Check for tools
 AC_PROG_CC


### PR DESCRIPTION
* build: Use the form of AC_INIT with arguments
    
    AC_INIT with no arguments is deprecated, and so is the 2-argument form
    of AM_INIT_AUTOMAKE (since 2002). The post-2002 equivalent is to
    pass the project name and the version number to AC_INIT, which defines
    VERSION from its argument.
    
    AC_INIT does not support the version number being expanded from shell
    variables, so convert it to be expanded from m4 macros.
    
    To preserve the tarball release names that SDL_ttf has traditionally
    used, we need to use the 4-argument form of AC_INIT. because by default
    Autoconf normalizes the name to lower-case. While we're doing that,
    we might as well use a non-empty third argument to specify the bug
    reporting address.

* build: Move Automake options into configure.ac
    
    Some Automake options, such as tar-ustar, can only be passed in this
    way, and cannot be in the $(AUTOMAKE_OPTIONS) make variable.

* build: Use POSIX 1003.1-2001 tar archives for `make dist`
    
    The Automake default is to use ancient UNIX v7 tar archives, which do
    not support long filenames, causing some of the macOS stuff to be
    excluded from `make dist`.
    
    Resolves: https://github.com/libsdl-org/SDL_ttf/issues/124