### PR TITLE
CMake: Support static-only SDL2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,7 +57,13 @@ set(SDL_TTF_VERSION "${SDL_TTF_MAJOR_VERSION}.${SDL_TTF_MINOR_VERSION}.${SDL_TTF
 
 ##### library generation #####
 add_library(SDL2_ttf SDL_ttf.c SDL_ttf.h)
-target_link_libraries(SDL2_ttf SDL2::SDL2 Freetype::Freetype)
+if (BUILD_SHARED_LIBS)
+  target_link_libraries(SDL2_ttf SDL2::SDL2)
+else ()
+  target_link_libraries(SDL2_ttf SDL2::SDL2-static)
+  set_target_properties(SDL2_ttf PROPERTIES POSITION_INDEPENDENT_CODE ON)
+endif ()
+target_link_libraries(SDL2_ttf Freetype::Freetype)
 target_include_directories(SDL2_ttf PUBLIC $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/SDL2>)
 
 install(


### PR DESCRIPTION
When SDL2 is built with `-DBUILD_SHARED_LIBS=OFF`, it does not define an `SDL2::SDL2` target.
    
Use `SDL2::SDL2-static` and set `POSITION_INDEPENDENT_CODE` if `BUILD_SHARED_LIBS` is `OFF`.

