### PR TITLE
add relative include path for SDL in Xcode project

### DIFF
--- a/Xcode/SDL_ttf.xcodeproj/project.pbxproj
+++ b/Xcode/SDL_ttf.xcodeproj/project.pbxproj
@@ -2000,7 +2000,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "org.libsdl.SDL2-ttf";
 				PRODUCT_NAME = SDL2_ttf;
 				TVOS_DEPLOYMENT_TARGET = 9.0;
-				USER_HEADER_SEARCH_PATHS = "\"$(SRCROOT)/../external/freetype-2.10.4/include\" \"$(SRCROOT)/../external/harfbuzz-2.8.0\" \"$(SRCROOT)/../external/harfbuzz-2.8.0/src\"";
+				USER_HEADER_SEARCH_PATHS = "\"$(SRCROOT)/../external/freetype-2.10.4/include\" \"$(SRCROOT)/../external/harfbuzz-2.8.0\" \"$(SRCROOT)/../external/harfbuzz-2.8.0/src\" $(PROJECT_DIR)/../../SDL/include";
 			};
 			name = Debug;
 		};
@@ -2069,7 +2069,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "org.libsdl.SDL2-ttf";
 				PRODUCT_NAME = SDL2_ttf;
 				TVOS_DEPLOYMENT_TARGET = 9.0;
-				USER_HEADER_SEARCH_PATHS = "\"$(SRCROOT)/../external/freetype-2.10.4/include\" \"$(SRCROOT)/../external/harfbuzz-2.8.0\" \"$(SRCROOT)/../external/harfbuzz-2.8.0/src\"";
+				USER_HEADER_SEARCH_PATHS = "\"$(SRCROOT)/../external/freetype-2.10.4/include\" \"$(SRCROOT)/../external/harfbuzz-2.8.0\" \"$(SRCROOT)/../external/harfbuzz-2.8.0/src\" $(PROJECT_DIR)/../../SDL/include";
 			};
 			name = Release;
 		};


### PR DESCRIPTION
I previously had my project set up with an SDL_ttf submodule pointing to the Xcode-iOS project. The new Xcode project doesn't automatically include SDL when the submodules are placed in the same folder. This change corrects that.

Note: I tried including it in the normal "Header Search Paths", but it refused to work. It only worked as a user header search path