### PR TITLE
Get rid of remaining references to old mercurial repository

### DIFF
--- a/VisualC/external/lib/x64/LICENSE.freetype.txt
+++ b/VisualC/external/lib/x64/LICENSE.freetype.txt
@@ -1,5 +1,5 @@
 The source code to this library used with SDL_ttf can be found here:
-https://hg.libsdl.org/SDL_ttf/file/default/external
+https://github.com/libsdl-org/SDL_ttf/tree/main/external
 ---
 
                     The FreeType Project LICENSE

--- a/VisualC/external/lib/x64/LICENSE.zlib.txt
+++ b/VisualC/external/lib/x64/LICENSE.zlib.txt
@@ -1,5 +1,5 @@
 The source code to this library used with SDL_ttf can be found here:
-https://hg.libsdl.org/SDL_image/file/default/external
+https://github.com/libsdl-org/SDL_ttf/tree/main/external
 ---
 
 Copyright notice:

--- a/VisualC/external/lib/x86/LICENSE.freetype.txt
+++ b/VisualC/external/lib/x86/LICENSE.freetype.txt
@@ -1,5 +1,5 @@
 The source code to this library used with SDL_ttf can be found here:
-https://hg.libsdl.org/SDL_ttf/file/default/external
+https://github.com/libsdl-org/SDL_ttf/tree/main/external
 ---
 
                     The FreeType Project LICENSE

--- a/VisualC/external/lib/x86/LICENSE.zlib.txt
+++ b/VisualC/external/lib/x86/LICENSE.zlib.txt
@@ -1,5 +1,5 @@
 The source code to this library used with SDL_ttf can be found here:
-https://hg.libsdl.org/SDL_image/file/default/external
+https://github.com/libsdl-org/SDL_ttf/tree/main/external
 ---
 
 Copyright notice:


### PR DESCRIPTION
This is super minor, but I thought I might as well submit it.