### PR TITLE
Add functions to use FreeType ClearType-style LCD rendering

### DIFF
--- a/SDL_ttf.c
+++ b/SDL_ttf.c
@@ -168,11 +168,13 @@ static SDL_INLINE int hasNEON()
 #define DIVIDE_BY_255(x)    DIVIDE_BY_255_SIGNED(x, 1)
 
 
-#define CACHED_METRICS  0x10
+#define CACHED_METRICS  0x20
+
 #define CACHED_BITMAP   0x01
 #define CACHED_PIXMAP   0x02
 #define CACHED_COLOR    0x04
-#define CACHED_SUBPIX   0x08
+#define CACHED_LCD      0x08
+#define CACHED_SUBPIX   0x10
 
 
 typedef struct {
@@ -298,7 +300,8 @@ static int TTF_byteswapped = 0;
 typedef enum {
     RENDER_SOLID = 0,
     RENDER_SHADED,
-    RENDER_BLENDED
+    RENDER_BLENDED,
+    RENDER_LCD
 } render_mode_t;
 
 typedef enum {
@@ -323,7 +326,7 @@ static SDL_Surface* TTF_Render_Wrapped_Internal(TTF_Font *font, const char *text
         SDL_Color fg, SDL_Color bg, Uint32 wrapLength, render_mode_t render_mode);
 
 static SDL_INLINE int Find_GlyphByIndex(TTF_Font *font, FT_UInt idx,
-        int want_bitmap, int want_pixmap, int want_color, int want_subpixel,
+        int want_bitmap, int want_pixmap, int want_color, int want_lcd, int want_subpixel,
         int translation, c_glyph **out_glyph, TTF_Image **out_image);
 
 static void Flush_Cache(TTF_Font *font);
@@ -395,6 +398,72 @@ static SDL_INLINE void BG_Blended_Color(const TTF_Image *image, Uint32 *destinat
             dst = (Uint32 *)((Uint8 *)dst + dstskip);
         }
     }
+}
+
+/* Blend with LCD rendering */
+static SDL_INLINE void BG_Blended_LCD(const TTF_Image *image, Uint32 *destination, Sint32 srcskip, Uint32 dstskip, SDL_Color *fg)
+{
+    const Uint32 *src   = (Uint32 *)image->buffer;
+    Uint32      *dst    = destination;
+    Uint32       width  = image->width;
+    Uint32       height = image->rows;
+
+    Uint32 tmp, bg;
+    Uint32 r, g, b;
+    Uint8 fg_r, fg_g, fg_b;
+    Uint8 bg_r, bg_g, bg_b;
+    Uint32 bg_a;
+
+    fg_r = fg->r;
+    fg_g = fg->g;
+    fg_b = fg->b;
+
+    int x, y = 0;
+
+    while (height--) {
+        y++;
+        x = 0;
+        /* *INDENT-OFF* */
+        DUFFS_LOOP4(
+                x++;
+                tmp = *src++;
+
+                if (tmp) {
+
+                    bg = *dst;
+
+                    bg_a = bg & 0xff000000;
+                    bg_r = (bg >> 16) & 0xff;
+                    bg_g = (bg >> 8) & 0xff;
+                    bg_b = (bg >> 0) & 0xff;
+
+                    r = (tmp >> 16) & 0xff;
+                    g = (tmp >> 8) & 0xff;
+                    b = (tmp >> 0) & 0xff;
+
+                    r = fg_r * r + bg_r * (255 - r) + 127;
+                    r = DIVIDE_BY_255(r);
+
+                    g = fg_g * g + bg_g * (255 - g) + 127;
+                    g = DIVIDE_BY_255(g);
+
+                    b = fg_b * b + bg_b * (255 - b) + 127;
+                    b = DIVIDE_BY_255(b);
+
+                    r <<= 16;
+                    g <<= 8;
+                    b <<= 0;
+
+                    *dst = r | g | b | bg_a;
+                }
+                dst++;
+
+                , width);
+        /* *INDENT-ON* */
+        src = (const Uint32 *)((const Uint8 *)src + srcskip);
+        dst = (Uint32 *)((Uint8 *)dst + dstskip);
+    }
+
 }
 
 #if TTF_USE_SDF
@@ -918,7 +987,7 @@ static void Draw_Line(const SDL_Surface *textbuf, int row, int line_width, int l
     /* Wrapped mode with an unbroken line: 'line_width' is greater that 'textbuf->w' */
     line_width = SDL_min(line_width, textbuf->w);
 
-    if (render_mode == RENDER_BLENDED) {
+    if (render_mode == RENDER_BLENDED || render_mode == RENDER_LCD) {
         while (line_thickness--) {
             SDL_memset4(dst, color, line_width);
             dst += textbuf->pitch;
@@ -931,7 +1000,7 @@ static void Draw_Line(const SDL_Surface *textbuf, int row, int line_width, int l
     }
 }
 
-static void clip_glyph(int *_x, int *_y, TTF_Image *image, const SDL_Surface *textbuf)
+static void clip_glyph(int *_x, int *_y, TTF_Image *image, const SDL_Surface *textbuf, int is_lcd)
 {
     int above_w;
     int above_h;
@@ -939,8 +1008,7 @@ static void clip_glyph(int *_x, int *_y, TTF_Image *image, const SDL_Surface *te
     int y = *_y;
 
     int srcbpp = 1;
-    if (image->is_color) {
-        /* This isn't tested because colored image never ends up left clipped */
+    if (image->is_color || is_lcd) {
         srcbpp = 4;
     }
 
@@ -1010,14 +1078,15 @@ static int Get_Alignement()
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-value"
 #endif
-#define BUILD_RENDER_LINE(NAME, IS_BLENDED, IS_BLENDED_OPAQUE, WB_WP_WC, WS, BLIT_GLYPH_BLENDED_OPAQUE_OPTIM, BLIT_GLYPH_BLENDED_OPTIM, BLIT_GLYPH_OPTIM) \
+#define BUILD_RENDER_LINE(NAME, IS_BLENDED, IS_BLENDED_OPAQUE, IS_LCD, WB_WP_WC, WS, BLIT_GLYPH_BLENDED_OPAQUE_OPTIM, BLIT_GLYPH_BLENDED_OPTIM, BLIT_GLYPH_OPTIM) \
                                                                                                                         \
 static SDL_INLINE                                                                                                       \
-int Render_Line_##NAME(TTF_Font *font, SDL_Surface *textbuf, int xstart, int ystart, Uint8 fg_alpha)                    \
+int Render_Line_##NAME(TTF_Font *font, SDL_Surface *textbuf, int xstart, int ystart, SDL_Color *fg)                     \
 {                                                                                                                       \
     const int alignment = Get_Alignement() - 1;                                                                         \
-    const int bpp = ((IS_BLENDED) ? 4 : 1);                                                                             \
+    const int bpp = ((IS_BLENDED || IS_LCD) ? 4 : 1);                                                                   \
     unsigned int i;                                                                                                     \
+    Uint8 fg_alpha = (fg ? fg->a : 0);                                                                                  \
     for (i = 0; i < font->pos_len; i++) {                                                                               \
         FT_UInt idx = font->pos_buf[i].index;                                                                           \
         int x       = font->pos_buf[i].x;                                                                               \
@@ -1054,7 +1123,16 @@ int Render_Line_##NAME(TTF_Font *font, SDL_Surface *textbuf, int xstart, int yst
                 srcskip = image->pitch - image->width;                                                                  \
                 dstskip = textbuf->pitch - image->width * bpp;                                                          \
                 /* Render glyph at (x, y) with optimized copy functions */                                              \
-                if (!IS_BLENDED || image->is_color == 0) {                                                              \
+                if (IS_LCD) {                                                                                           \
+                    image->buffer = saved_buffer;                                                                       \
+                    image->buffer += alignment;                                                                         \
+                    image->width = saved_width;                                                                         \
+                    dst = (Uint8 *)textbuf->pixels + y * textbuf->pitch + x * bpp;                                      \
+                    /* Compute srcskip, dstskip */                                                                      \
+                    srcskip = image->pitch - 4 * image->width;                                                          \
+                    dstskip = textbuf->pitch - image->width * bpp;                                                      \
+                    BG_Blended_LCD(image, (Uint32 *)dst, srcskip, dstskip, fg);                                         \
+                } else if (!IS_BLENDED || image->is_color == 0) {                                                       \
                     if (IS_BLENDED_OPAQUE) {                                                                            \
                         BLIT_GLYPH_BLENDED_OPAQUE_OPTIM(image, (Uint32 *)dst, srcskip, dstskip);                        \
                     } else if (IS_BLENDED) {                                                                            \
@@ -1078,14 +1156,17 @@ int Render_Line_##NAME(TTF_Font *font, SDL_Surface *textbuf, int xstart, int yst
                 /* Modify a copy, and clip it */                                                                        \
                 TTF_Image image_clipped = *image;                                                                       \
                 /* Intersect image glyph at (x,y) with textbuf */                                                       \
-                clip_glyph(&x, &y, &image_clipped, textbuf);                                                            \
+                clip_glyph(&x, &y, &image_clipped, textbuf, IS_LCD);                                                    \
                 /* Compute dst */                                                                                       \
                 dst = (Uint8 *)textbuf->pixels + y * textbuf->pitch + x * bpp;                                          \
                 /* Compute srcskip, dstskip */                                                                          \
                 srcskip = image_clipped.pitch - image_clipped.width;                                                    \
                 dstskip = textbuf->pitch - image_clipped.width * bpp;                                                   \
                 /* Render glyph at (x, y) */                                                                            \
-                if (!IS_BLENDED || image->is_color == 0) {                                                              \
+                if (IS_LCD) {                                                                                           \
+                    srcskip -= 3 * image_clipped.width;                                                                 \
+                    BG_Blended_LCD(&image_clipped, (Uint32 *)dst, srcskip, dstskip, fg);                                \
+                } else if (!IS_BLENDED || image->is_color == 0) {                                                       \
                     if (IS_BLENDED_OPAQUE) {                                                                            \
                         BG_Blended_Opaque(&image_clipped, (Uint32 *)dst, srcskip, dstskip);                             \
                     } else if (IS_BLENDED) {                                                                            \
@@ -1108,107 +1189,125 @@ int Render_Line_##NAME(TTF_Font *font, SDL_Surface *textbuf, int xstart, int yst
 }                                                                                                                       \
                                                                                                                         \
 
-#define BITMAP  CACHED_BITMAP, 0, 0
-#define PIXMAP  0, CACHED_PIXMAP, 0
-#define COLOR   0, 0, CACHED_COLOR
+#define BITMAP  CACHED_BITMAP, 0, 0, 0
+#define PIXMAP  0, CACHED_PIXMAP, 0, 0
+#define COLOR   0, 0, CACHED_COLOR, 0
+#define LCD     0, 0, 0, CACHED_LCD
 
 #define SUBPIX  CACHED_SUBPIX
 
-/* BUILD_RENDER_LINE(NAME, IS_BLENDED, IS_BLENDED_OPAQUE, WANT_BITMAP_PIXMAP_COLOR, WANT_SUBPIXEL, BLIT_GLYPH_BLENDED_OPAQUE_OPTIM, BLIT_GLYPH_BLENDED_OPTIM, BLIT_GLYPH_OPTIM) */
+/* BUILD_RENDER_LINE(NAME, IS_BLENDED, IS_BLENDED_OPAQUE, WANT_BITMAP_PIXMAP_COLOR_LCD, WANT_SUBPIXEL, BLIT_GLYPH_BLENDED_OPAQUE_OPTIM, BLIT_GLYPH_BLENDED_OPTIM, BLIT_GLYPH_OPTIM) */
 
 #if defined(HAVE_SSE2_INTRINSICS)
-BUILD_RENDER_LINE(SSE_Shaded            , 0, 0, PIXMAP, 0     ,                       ,                , BG_SSE     )
-BUILD_RENDER_LINE(SSE_Blended           , 1, 0,  COLOR, 0     ,                       , BG_Blended_SSE ,            )
-BUILD_RENDER_LINE(SSE_Blended_Opaque    , 1, 1,  COLOR, 0     , BG_Blended_Opaque_SSE ,                ,            )
-BUILD_RENDER_LINE(SSE_Solid             , 0, 0, BITMAP, 0     ,                       ,                , BG_SSE     )
-BUILD_RENDER_LINE(SSE_Shaded_SP         , 0, 0, PIXMAP, SUBPIX,                       ,                , BG_SSE     )
-BUILD_RENDER_LINE(SSE_Blended_SP        , 1, 0,  COLOR, SUBPIX,                       , BG_Blended_SSE ,            )
-BUILD_RENDER_LINE(SSE_Blended_Opaque_SP , 1, 1,  COLOR, SUBPIX, BG_Blended_Opaque_SSE ,                ,            )
+BUILD_RENDER_LINE(SSE_Shaded            , 0, 0, 0, PIXMAP, 0     ,                       ,                , BG_SSE     )
+BUILD_RENDER_LINE(SSE_Blended           , 1, 0, 0,  COLOR, 0     ,                       , BG_Blended_SSE ,            )
+BUILD_RENDER_LINE(SSE_Blended_Opaque    , 1, 1, 0,  COLOR, 0     , BG_Blended_Opaque_SSE ,                ,            )
+BUILD_RENDER_LINE(SSE_Solid             , 0, 0, 0, BITMAP, 0     ,                       ,                , BG_SSE     )
+BUILD_RENDER_LINE(SSE_Shaded_SP         , 0, 0, 0, PIXMAP, SUBPIX,                       ,                , BG_SSE     )
+BUILD_RENDER_LINE(SSE_Blended_SP        , 1, 0, 0,  COLOR, SUBPIX,                       , BG_Blended_SSE ,            )
+BUILD_RENDER_LINE(SSE_Blended_Opaque_SP , 1, 1, 0,  COLOR, SUBPIX, BG_Blended_Opaque_SSE ,                ,            )
+BUILD_RENDER_LINE(SSE_LCD               , 0, 0, 1,    LCD, 0,                            ,                ,            )
+BUILD_RENDER_LINE(SSE_LCD_SP            , 0, 0, 1,    LCD, SUBPIX,                       ,                ,            )
 #endif
 
 #if defined(HAVE_NEON_INTRINSICS)
-BUILD_RENDER_LINE(NEON_Shaded           , 0, 0, PIXMAP, 0     ,                       ,                , BG_NEON    )
-BUILD_RENDER_LINE(NEON_Blended          , 1, 0,  COLOR, 0     ,                       , BG_Blended_NEON,            )
-BUILD_RENDER_LINE(NEON_Blended_Opaque   , 1, 1,  COLOR, 0     , BG_Blended_Opaque_NEON,                ,            )
-BUILD_RENDER_LINE(NEON_Solid            , 0, 0, BITMAP, 0     ,                       ,                , BG_NEON    )
-BUILD_RENDER_LINE(NEON_Shaded_SP        , 0, 0, PIXMAP, SUBPIX,                       ,                , BG_NEON    )
-BUILD_RENDER_LINE(NEON_Blended_SP       , 1, 0,  COLOR, SUBPIX,                       , BG_Blended_NEON,            )
-BUILD_RENDER_LINE(NEON_Blended_Opaque_SP, 1, 1,  COLOR, SUBPIX, BG_Blended_Opaque_NEON,                ,            )
+BUILD_RENDER_LINE(NEON_Shaded           , 0, 0, 0, PIXMAP, 0     ,                       ,                , BG_NEON    )
+BUILD_RENDER_LINE(NEON_Blended          , 1, 0, 0,  COLOR, 0     ,                       , BG_Blended_NEON,            )
+BUILD_RENDER_LINE(NEON_Blended_Opaque   , 1, 1, 0,  COLOR, 0     , BG_Blended_Opaque_NEON,                ,            )
+BUILD_RENDER_LINE(NEON_Solid            , 0, 0, 0, BITMAP, 0     ,                       ,                , BG_NEON    )
+BUILD_RENDER_LINE(NEON_Shaded_SP        , 0, 0, 0, PIXMAP, SUBPIX,                       ,                , BG_NEON    )
+BUILD_RENDER_LINE(NEON_Blended_SP       , 1, 0, 0,  COLOR, SUBPIX,                       , BG_Blended_NEON,            )
+BUILD_RENDER_LINE(NEON_Blended_Opaque_SP, 1, 1, 0,  COLOR, SUBPIX, BG_Blended_Opaque_NEON,                ,            )
+BUILD_RENDER_LINE(NEON_LCD              , 0, 0, 1,    LCD, 0     ,                       ,                ,            )
+BUILD_RENDER_LINE(NEON_LCD_SP           , 0, 0, 1,    LCD, SUBPIX,                       ,                ,            )
 #endif
 
 #if defined(HAVE_BLIT_GLYPH_64)
-BUILD_RENDER_LINE(64_Shaded             , 0, 0, PIXMAP, 0     ,                       ,                , BG_64      )
-BUILD_RENDER_LINE(64_Blended            , 1, 0,  COLOR, 0     ,                       , BG_Blended_32  ,            )
-BUILD_RENDER_LINE(64_Blended_Opaque     , 1, 1,  COLOR, 0     , BG_Blended_Opaque_32  ,                ,            )
-BUILD_RENDER_LINE(64_Solid              , 0, 0, BITMAP, 0     ,                       ,                , BG_64      )
-BUILD_RENDER_LINE(64_Shaded_SP          , 0, 0, PIXMAP, SUBPIX,                       ,                , BG_64      )
-BUILD_RENDER_LINE(64_Blended_SP         , 1, 0,  COLOR, SUBPIX,                       , BG_Blended_32  ,            )
-BUILD_RENDER_LINE(64_Blended_Opaque_SP  , 1, 1,  COLOR, SUBPIX, BG_Blended_Opaque_32  ,                ,            )
+BUILD_RENDER_LINE(64_Shaded             , 0, 0, 0, PIXMAP, 0     ,                       ,                , BG_64      )
+BUILD_RENDER_LINE(64_Blended            , 1, 0, 0,  COLOR, 0     ,                       , BG_Blended_32  ,            )
+BUILD_RENDER_LINE(64_Blended_Opaque     , 1, 1, 0,  COLOR, 0     , BG_Blended_Opaque_32  ,                ,            )
+BUILD_RENDER_LINE(64_Solid              , 0, 0, 0, BITMAP, 0     ,                       ,                , BG_64      )
+BUILD_RENDER_LINE(64_Shaded_SP          , 0, 0, 0, PIXMAP, SUBPIX,                       ,                , BG_64      )
+BUILD_RENDER_LINE(64_Blended_SP         , 1, 0, 0,  COLOR, SUBPIX,                       , BG_Blended_32  ,            )
+BUILD_RENDER_LINE(64_Blended_Opaque_SP  , 1, 1, 0,  COLOR, SUBPIX, BG_Blended_Opaque_32  ,                ,            )
+BUILD_RENDER_LINE(64_LCD                , 0, 0, 1,    LCD, 0     ,                       ,                ,            )
+BUILD_RENDER_LINE(64_LCD_SP             , 0, 0, 1,    LCD, SUBPIX,                       ,                ,            )
 #elif defined(HAVE_BLIT_GLYPH_32)
-BUILD_RENDER_LINE(32_Shaded             , 0, 0, PIXMAP, 0     ,                       ,                , BG_32      )
-BUILD_RENDER_LINE(32_Blended            , 1, 0,  COLOR, 0     ,                       , BG_Blended_32  ,            )
-BUILD_RENDER_LINE(32_Blended_Opaque     , 1, 1,  COLOR, 0     , BG_Blended_Opaque_32  ,                ,            )
-BUILD_RENDER_LINE(32_Solid              , 0, 0, BITMAP, 0     ,                       ,                , BG_32      )
-BUILD_RENDER_LINE(32_Shaded_SP          , 0, 0, PIXMAP, SUBPIX,                       ,                , BG_32      )
-BUILD_RENDER_LINE(32_Blended_SP         , 1, 0,  COLOR, SUBPIX,                       , BG_Blended_32  ,            )
-BUILD_RENDER_LINE(32_Blended_Opaque_SP  , 1, 1,  COLOR, SUBPIX, BG_Blended_Opaque_32  ,                ,            )
+BUILD_RENDER_LINE(32_Shaded             , 0, 0, 0, PIXMAP, 0     ,                       ,                , BG_32      )
+BUILD_RENDER_LINE(32_Blended            , 1, 0, 0,  COLOR, 0     ,                       , BG_Blended_32  ,            )
+BUILD_RENDER_LINE(32_Blended_Opaque     , 1, 1, 0,  COLOR, 0     , BG_Blended_Opaque_32  ,                ,            )
+BUILD_RENDER_LINE(32_Solid              , 0, 0, 0, BITMAP, 0     ,                       ,                , BG_32      )
+BUILD_RENDER_LINE(32_Shaded_SP          , 0, 0, 0, PIXMAP, SUBPIX,                       ,                , BG_32      )
+BUILD_RENDER_LINE(32_Blended_SP         , 1, 0, 0,  COLOR, SUBPIX,                       , BG_Blended_32  ,            )
+BUILD_RENDER_LINE(32_Blended_Opaque_SP  , 1, 1, 0,  COLOR, SUBPIX, BG_Blended_Opaque_32  ,                ,            )
+BUILD_RENDER_LINE(32_LCD                , 0, 0, 1,    LCD, 0     ,                       ,                ,            )
+BUILD_RENDER_LINE(32_LCD_SP             , 0, 0, 1,    LCD, SUBPIX,                       ,                ,            )
 #else
-BUILD_RENDER_LINE(8_Shaded              , 0, 0, PIXMAP, 0     ,                       ,                , BG         )
-BUILD_RENDER_LINE(8_Blended             , 1, 0,  COLOR, 0     ,                       , BG_Blended     ,            )
-BUILD_RENDER_LINE(8_Blended_Opaque      , 1, 1,  COLOR, 0     , BG_Blended_Opaque     ,                ,            )
-BUILD_RENDER_LINE(8_Solid               , 0, 0, BITMAP, 0     ,                       ,                , BG         )
-BUILD_RENDER_LINE(8_Shaded_SP           , 0, 0, PIXMAP, SUBPIX,                       ,                , BG         )
-BUILD_RENDER_LINE(8_Blended_SP          , 1, 0,  COLOR, SUBPIX,                       , BG_Blended     ,            )
-BUILD_RENDER_LINE(8_Blended_Opaque_SP   , 1, 1,  COLOR, SUBPIX, BG_Blended_Opaque     ,                ,            )
+BUILD_RENDER_LINE(8_Shaded              , 0, 0, 0, PIXMAP, 0     ,                       ,                , BG         )
+BUILD_RENDER_LINE(8_Blended             , 1, 0, 0,  COLOR, 0     ,                       , BG_Blended     ,            )
+BUILD_RENDER_LINE(8_Blended_Opaque      , 1, 1, 0,  COLOR, 0     , BG_Blended_Opaque     ,                ,            )
+BUILD_RENDER_LINE(8_Solid               , 0, 0, 0, BITMAP, 0     ,                       ,                , BG         )
+BUILD_RENDER_LINE(8_Shaded_SP           , 0, 0, 0, PIXMAP, SUBPIX,                       ,                , BG         )
+BUILD_RENDER_LINE(8_Blended_SP          , 1, 0, 0,  COLOR, SUBPIX,                       , BG_Blended     ,            )
+BUILD_RENDER_LINE(8_Blended_Opaque_SP   , 1, 1, 0,  COLOR, SUBPIX, BG_Blended_Opaque     ,                ,            )
+BUILD_RENDER_LINE(8_LCD                 , 0, 0, 1,    LCD, 0     ,                       ,                ,            )
+BUILD_RENDER_LINE(8_LCD_SP              , 0, 0, 1,    LCD, SUBPIX,                       ,                ,            )
 #endif
 
 
 #if TTF_USE_SDF
-static int (*Render_Line_SDF_Shaded)(TTF_Font *font, SDL_Surface *textbuf, int xstart, int ystart, Uint8 fg_alpha) = NULL;
-BUILD_RENDER_LINE(SDF_Blended           , 1, 0,  COLOR, 0     ,                       , BG_Blended_SDF ,            )
-BUILD_RENDER_LINE(SDF_Blended_Opaque    , 1, 1,  COLOR, 0     , BG_Blended_Opaque_SDF ,                ,            )
-static int (*Render_Line_SDF_Solid)(TTF_Font *font, SDL_Surface *textbuf, int xstart, int ystart, Uint8 fg_alpha) = NULL;
-static int (*Render_Line_SDF_Shaded_SP)(TTF_Font *font, SDL_Surface *textbuf, int xstart, int ystart, Uint8 fg_alpha) = NULL;
-BUILD_RENDER_LINE(SDF_Blended_SP        , 1, 0,  COLOR, SUBPIX,                       , BG_Blended_SDF ,            )
-BUILD_RENDER_LINE(SDF_Blended_Opaque_SP , 1, 1,  COLOR, SUBPIX, BG_Blended_Opaque_SDF ,                ,            )
+static int (*Render_Line_SDF_Shaded)(TTF_Font *font, SDL_Surface *textbuf, int xstart, int ystart, SDL_Color *fg) = NULL;
+BUILD_RENDER_LINE(SDF_Blended           , 1, 0, 0,  COLOR, 0     ,                       , BG_Blended_SDF ,            )
+BUILD_RENDER_LINE(SDF_Blended_Opaque    , 1, 1, 0,  COLOR, 0     , BG_Blended_Opaque_SDF ,                ,            )
+static int (*Render_Line_SDF_Solid)(TTF_Font *font, SDL_Surface *textbuf, int xstart, int ystart, SDL_Color *fg) = NULL;
+static int (*Render_Line_SDF_Shaded_SP)(TTF_Font *font, SDL_Surface *textbuf, int xstart, int ystart, SDL_Color *fg) = NULL;
+BUILD_RENDER_LINE(SDF_Blended_SP        , 1, 0, 0,  COLOR, SUBPIX,                       , BG_Blended_SDF ,            )
+BUILD_RENDER_LINE(SDF_Blended_Opaque_SP , 1, 1, 0,  COLOR, SUBPIX, BG_Blended_Opaque_SDF ,                ,            )
+static int (*Render_Line_SDF_LCD)(TTF_Font *font, SDL_Surface *textbuf, int xstart, int ystart, SDL_Color *fg) = NULL;
+static int (*Render_Line_SDF_LCD_SP)(TTF_Font *font, SDL_Surface *textbuf, int xstart, int ystart, SDL_Color *fg) = NULL;
 #endif
 
 #ifdef __GNUC__
 #pragma GCC diagnostic pop
 #endif
 
-static SDL_INLINE int Render_Line(const render_mode_t render_mode, int subpixel, TTF_Font *font, SDL_Surface *textbuf, int xstart, int ystart, Uint8 fg_alpha)
+static SDL_INLINE int Render_Line(const render_mode_t render_mode, int subpixel, TTF_Font *font, SDL_Surface *textbuf, int xstart, int ystart, SDL_Color fg)
 {
     /* Render line (pos_buf) to textbuf at (xstart, ystart) */
 
     /* Subpixel with RENDER_SOLID doesn't make sense. */
     /* (and 'cached->subpixel.translation' would need to distinguish bitmap/pixmap). */
-
-    int is_opaque = (fg_alpha == SDL_ALPHA_OPAQUE);
+    int is_opaque = (fg.a == SDL_ALPHA_OPAQUE);
 
 #define Call_Specific_Render_Line(NAME)                                                                     \
         if (render_mode == RENDER_SHADED) {                                                                 \
             if (subpixel == 0) {                                                                            \
-                return Render_Line_##NAME##_Shaded(font, textbuf, xstart, ystart, 0);                       \
+                return Render_Line_##NAME##_Shaded(font, textbuf, xstart, ystart, NULL);                    \
             } else {                                                                                        \
-                return Render_Line_##NAME##_Shaded_SP(font, textbuf, xstart, ystart, 0);                    \
+                return Render_Line_##NAME##_Shaded_SP(font, textbuf, xstart, ystart, NULL);                 \
             }                                                                                               \
         } else if (render_mode == RENDER_BLENDED) {                                                         \
             if (is_opaque) {                                                                                \
                 if (subpixel == 0) {                                                                        \
-                    return Render_Line_##NAME##_Blended_Opaque(font, textbuf, xstart, ystart, 0);           \
+                    return Render_Line_##NAME##_Blended_Opaque(font, textbuf, xstart, ystart, NULL);        \
                 } else {                                                                                    \
-                    return Render_Line_##NAME##_Blended_Opaque_SP(font, textbuf, xstart, ystart, 0);        \
+                    return Render_Line_##NAME##_Blended_Opaque_SP(font, textbuf, xstart, ystart, NULL);     \
                 }                                                                                           \
             } else {                                                                                        \
                 if (subpixel == 0) {                                                                        \
-                    return Render_Line_##NAME##_Blended(font, textbuf, xstart, ystart, fg_alpha);           \
+                    return Render_Line_##NAME##_Blended(font, textbuf, xstart, ystart, &fg);                \
                 } else {                                                                                    \
-                    return Render_Line_##NAME##_Blended_SP(font, textbuf, xstart, ystart, fg_alpha);        \
+                    return Render_Line_##NAME##_Blended_SP(font, textbuf, xstart, ystart, &fg);             \
                 }                                                                                           \
             }                                                                                               \
+        } else if (render_mode == RENDER_LCD) {                                                             \
+            if (subpixel == 0) {                                                                            \
+                return Render_Line_##NAME##_LCD(font, textbuf, xstart, ystart, &fg);                        \
+            } else {                                                                                        \
+                return Render_Line_##NAME##_LCD_SP(font, textbuf, xstart, ystart, &fg);                     \
+            }                                                                                               \
         } else {                                                                                            \
-            return Render_Line_##NAME##_Solid(font, textbuf, xstart, ystart, 0);                            \
+            return Render_Line_##NAME##_Solid(font, textbuf, xstart, ystart, NULL);                         \
         }
 
 #if TTF_USE_SDF
@@ -1448,6 +1547,68 @@ static SDL_Surface *Create_Surface_Blended(int width, int height, SDL_Color fg, 
 
     return textbuf;
 }
+
+static SDL_Surface* Create_Surface_LCD(int width, int height, SDL_Color fg, SDL_Color bg, Uint32 *color)
+{
+    const int alignment = Get_Alignement() - 1;
+    SDL_Surface *textbuf = NULL;
+    Uint32 bgcolor;
+
+    /* Background color */
+    bgcolor = (bg.a << 24) | (bg.r << 16) | (bg.g << 8) | bg.b;
+
+    /* Underline/Strikethrough color style */
+    *color = (bg.a << 24) | (fg.r << 16) | (fg.g << 8) | fg.b;
+
+    /* Create the target surface if required */
+    if (width != 0) {
+        /* Create a surface with memory:
+         * - pitch is rounded to alignment
+         * - adress is aligned
+         */
+        Sint64 size;
+        void *pixels, *ptr;
+        /* Worse case at the end of line pulling 'alignment' extra blank pixels */
+        int pitch = (width + alignment) * 4;
+        pitch += alignment;
+        pitch &= ~alignment;
+        size = height * pitch + sizeof (void *) + alignment;
+        if (size < 0 || size > SDL_MAX_SINT32) {
+            /* Overflow... */
+            return NULL;
+        }
+
+        ptr = SDL_malloc((size_t)size);
+        if (ptr == NULL) {
+            return NULL;
+        }
+
+        /* address is aligned */
+        pixels = (void *)(((size_t)ptr + sizeof(void *) + alignment) & ~alignment);
+        ((void **)pixels)[-1] = ptr;
+
+        textbuf = SDL_CreateRGBSurfaceWithFormatFrom(pixels, width, height, 0, pitch, SDL_PIXELFORMAT_ARGB8888);
+        if (textbuf == NULL) {
+            SDL_free(ptr);
+            return NULL;
+        }
+
+        /* Let SDL handle the memory allocation */
+        textbuf->flags &= ~SDL_PREALLOC;
+        textbuf->flags |= SDL_SIMD_ALIGNED;
+
+        /* Initialize with fg and 0 alpha */
+        SDL_memset4(pixels, bgcolor, (height * pitch) / 4);
+
+        /* Support alpha blending */
+        if (bg.a != SDL_ALPHA_OPAQUE) {
+            SDL_SetSurfaceBlendMode(textbuf, SDL_BLENDMODE_BLEND);
+        }
+    }
+
+    return textbuf;
+}
+
 
 /* rcg06192001 get linked library's version. */
 const SDL_version* TTF_Linked_Version(void)
@@ -1918,6 +2079,13 @@ static FT_Error Load_Glyph(TTF_Font *font, c_glyph *cached, int want, int transl
     /* Get our glyph shortcut */
     slot = font->face->glyph;
 
+    if (want & CACHED_LCD) {
+        if (slot->format == FT_GLYPH_FORMAT_BITMAP) {
+            TTF_SetError("LCD mode not possible with bitmap font");
+            return -1;
+        }
+    }
+
     /* Get the glyph metrics, always needed */
     if (cached->stored == 0) {
         cached->sz_left  = slot->bitmap_left;
@@ -1991,6 +2159,7 @@ static FT_Error Load_Glyph(TTF_Font *font, c_glyph *cached, int want, int transl
     if (((want & CACHED_BITMAP) && !(cached->stored & CACHED_BITMAP)) ||
         ((want & CACHED_PIXMAP) && !(cached->stored & CACHED_PIXMAP)) ||
         ((want & CACHED_COLOR) && !(cached->stored & CACHED_COLOR)) ||
+        ((want & CACHED_LCD) && !(cached->stored & CACHED_LCD)) ||
          (want & CACHED_SUBPIX)
        ) {
         const int  mono  = (want & CACHED_BITMAP);
@@ -2008,6 +2177,9 @@ static FT_Error Load_Glyph(TTF_Font *font, c_glyph *cached, int want, int transl
                 ft_render_mode = FT_RENDER_MODE_SDF;
             }
 #endif
+            if ((want & CACHED_LCD)) {
+                ft_render_mode = FT_RENDER_MODE_LCD;
+            }
         }
 
         /* Subpixel translation, flush previous datas */
@@ -2101,6 +2273,9 @@ static FT_Error Load_Glyph(TTF_Font *font, c_glyph *cached, int want, int transl
             dst->pitch += 3 * dst->width;
         }
 #endif
+        if (src->pixel_mode == FT_PIXEL_MODE_LCD) {
+            dst->pitch += 3 * dst->width;
+        }
 
         if (dst->rows != 0) {
             unsigned int i;
@@ -2147,6 +2322,9 @@ static FT_Error Load_Glyph(TTF_Font *font, c_glyph *cached, int want, int transl
                     quotient  = src->width;
                     remainder = 0;
 #endif
+                } else if (src->pixel_mode == FT_PIXEL_MODE_LCD) {
+                    quotient  = src->width / 3;
+                    remainder = 0;
                 } else {
                     quotient  = src->width;
                     remainder = 0;
@@ -2275,6 +2453,18 @@ static FT_Error Load_Glyph(TTF_Font *font, c_glyph *cached, int want, int transl
                 } else if (src->pixel_mode == FT_PIXEL_MODE_BGRA) {
                     SDL_memcpy(dstp, srcp, 4 * src->width);
 #endif
+                } else if (src->pixel_mode == FT_PIXEL_MODE_LCD) {
+                    while (quotient--) {
+                        Uint8 alpha = 0;
+                        Uint8 r, g, b;
+                        r = *srcp++;
+                        g = *srcp++;
+                        b = *srcp++;
+                        *dstp++ = b;
+                        *dstp++ = g;
+                        *dstp++ = r;
+                        *dstp++ = alpha;
+                    }
                 } else {
 #if TTF_USE_SDF
                     if (ft_render_mode != FT_RENDER_MODE_SDF) {
@@ -2288,10 +2478,9 @@ static FT_Error Load_Glyph(TTF_Font *font, c_glyph *cached, int want, int transl
                                 d = 256 - (128 - s) * 2;
                             } else {
                                 d = 255;
-                                /* some glitch ?
                                 if (s == 255) {
                                     d = 0;
-                                }*/
+                                }
                             }
                             dstp[x] = d;
                         }
@@ -2349,6 +2538,8 @@ static FT_Error Load_Glyph(TTF_Font *font, c_glyph *cached, int want, int transl
         /* Mark that we rendered this format */
         if (mono) {
             cached->stored |= CACHED_BITMAP;
+        } else if (src->pixel_mode == FT_PIXEL_MODE_LCD) {
+            cached->stored |= CACHED_LCD;
         } else {
 #if TTF_USE_COLOR
             if (want & CACHED_COLOR) {
@@ -2385,7 +2576,7 @@ ft_failure:
 }
 
 static SDL_INLINE int Find_GlyphByIndex(TTF_Font *font, FT_UInt idx,
-        int want_bitmap, int want_pixmap, int want_color, int want_subpixel,
+        int want_bitmap, int want_pixmap, int want_color, int want_lcd, int want_subpixel,
         int translation, c_glyph **out_glyph, TTF_Image **out_image)
 {
     /* cache size is 256, get key by masking */
@@ -2395,7 +2586,7 @@ static SDL_INLINE int Find_GlyphByIndex(TTF_Font *font, FT_UInt idx,
         *out_glyph = glyph;
     }
 
-    if (want_pixmap || want_color) {
+    if (want_pixmap || want_color || want_lcd) {
         *out_image = &glyph->pixmap;
     }
 
@@ -2408,7 +2599,7 @@ static SDL_INLINE int Find_GlyphByIndex(TTF_Font *font, FT_UInt idx,
         /* No a real cache, but if it always advances by integer pixels (eg translation 0 or same as previous),
          * this allows to render as fast as normal mode. */
         int retval;
-        int want = CACHED_METRICS | want_bitmap | want_pixmap | want_color | want_subpixel;
+        int want = CACHED_METRICS | want_bitmap | want_pixmap | want_color | want_lcd | want_subpixel;
 
         if (glyph->stored && glyph->index != idx) {
             Flush_Glyph(glyph);
@@ -2422,6 +2613,12 @@ static SDL_INLINE int Find_GlyphByIndex(TTF_Font *font, FT_UInt idx,
             return 0;
         }
 
+        if (want_color || want_pixmap || want_lcd) {
+            if (glyph->stored & (CACHED_COLOR|CACHED_PIXMAP|CACHED_LCD)) {
+                Flush_Glyph(glyph);
+            }
+        }
+
         glyph->index = idx;
         retval = Load_Glyph(font, glyph, want, translation);
         if (retval == 0) {
@@ -2433,7 +2630,7 @@ static SDL_INLINE int Find_GlyphByIndex(TTF_Font *font, FT_UInt idx,
     else
     {
         int retval;
-        const int want = CACHED_METRICS | want_bitmap | want_pixmap | want_color;
+        const int want = CACHED_METRICS | want_bitmap | want_pixmap | want_color | want_lcd;
 
         /* Faster check as it gets inlined */
         if (want_pixmap) {
@@ -2448,6 +2645,10 @@ static SDL_INLINE int Find_GlyphByIndex(TTF_Font *font, FT_UInt idx,
             if ((glyph->stored & CACHED_COLOR) && glyph->index == idx) {
                 return 0;
             }
+        } else if (want_lcd) {
+            if ((glyph->stored & CACHED_LCD) && glyph->index == idx) {
+                return 0;
+            }
         } else {
             /* Get metrics */
             if (glyph->stored && glyph->index == idx) {
@@ -2455,10 +2656,10 @@ static SDL_INLINE int Find_GlyphByIndex(TTF_Font *font, FT_UInt idx,
             }
         }
 
-        /* Cache cannot contain both PIXMAP and COLOR (unless COLOR is actually not colored). 
+        /* Cache cannot contain both PIXMAP and COLOR (unless COLOR is actually not colored) and LCD
            So, if it's already used, clear it */
-        if (want_color || want_pixmap) {
-            if (glyph->stored & (CACHED_COLOR|CACHED_PIXMAP)) {
+        if (want_color || want_pixmap || want_lcd) {
+            if (glyph->stored & (CACHED_COLOR|CACHED_PIXMAP|CACHED_LCD)) {
                 Flush_Glyph(glyph);
             }
         }
@@ -2498,7 +2699,7 @@ static SDL_INLINE FT_UInt get_char_index(TTF_Font *font, Uint32 ch)
 static SDL_INLINE int Find_GlyphMetrics(TTF_Font *font, Uint32 ch, c_glyph **out_glyph)
 {
     FT_UInt idx = get_char_index(font, ch);
-    return Find_GlyphByIndex(font, idx, 0, 0, 0, 0, 0, out_glyph, NULL);
+    return Find_GlyphByIndex(font, idx, 0, 0, 0, 0, 0, 0, out_glyph, NULL);
 }
 
 void TTF_CloseFont(TTF_Font *font)
@@ -2934,7 +3135,7 @@ static int TTF_Size_Internal(TTF_Font *font,
             continue;
         }
 #endif
-        if (Find_GlyphByIndex(font, idx, 0, 0, 0, 0, 0, &glyph, NULL) < 0) {
+        if (Find_GlyphByIndex(font, idx, 0, 0, 0, 0, 0, 0, &glyph, NULL) < 0) {
             goto failure;
         }
 
@@ -3125,6 +3326,11 @@ static SDL_Surface* TTF_Render_Internal(TTF_Font *font, const char *text, const 
     TTF_CHECK_POINTER(font, NULL);
     TTF_CHECK_POINTER(text, NULL);
 
+    if (render_mode == RENDER_LCD && !FT_IS_SCALABLE(font->face)) {
+        TTF_SetError("LCD rendering is not available for non-scalable font");
+        goto failure;
+    }
+
     /* Convert input string to default encoding UTF-8 */
     if (str_type == STR_TEXT) {
         utf8_alloc = SDL_stack_alloc(Uint8, LATIN1_to_UTF8_len(text));
@@ -3160,8 +3366,10 @@ static SDL_Surface* TTF_Render_Internal(TTF_Font *font, const char *text, const 
         textbuf = Create_Surface_Solid(width, height, fg, &color);
     } else if (render_mode == RENDER_SHADED) {
         textbuf = Create_Surface_Shaded(width, height, fg, bg, &color);
-    } else { /* render_mode == RENDER_BLENDED */
+    } else if (render_mode == RENDER_BLENDED) {
         textbuf = Create_Surface_Blended(width, height, fg, &color);
+    } else { /* render_mode == RENDER_LCD */
+        textbuf = Create_Surface_LCD(width, height, fg, bg, &color);
     }
 
     if (textbuf == NULL) {
@@ -3169,7 +3377,7 @@ static SDL_Surface* TTF_Render_Internal(TTF_Font *font, const char *text, const 
     }
 
     /* Render one text line to textbuf at (xstart, ystart) */
-    if (Render_Line(render_mode, font->render_subpixel, font, textbuf, xstart, ystart, fg.a) < 0) {
+    if (Render_Line(render_mode, font->render_subpixel, font, textbuf, xstart, ystart, fg) < 0) {
         goto failure;
     }
 
@@ -3277,6 +3485,39 @@ SDL_Surface* TTF_RenderUNICODE_Blended(TTF_Font *font, const Uint16 *text, SDL_C
     return TTF_Render_Internal(font, (const char *)text, STR_UNICODE, fg, fg /* unused */, RENDER_BLENDED);
 }
 
+SDL_Surface* TTF_RenderText_LCD(TTF_Font *font, const char *text, SDL_Color fg, SDL_Color bg)
+{
+    return TTF_Render_Internal(font, text, STR_TEXT, fg, bg, RENDER_LCD);
+}
+
+SDL_Surface* TTF_RenderUTF8_LCD(TTF_Font *font, const char *text, SDL_Color fg, SDL_Color bg)
+{
+    return TTF_Render_Internal(font, text, STR_UTF8, fg, bg, RENDER_LCD);
+}
+
+SDL_Surface* TTF_RenderUNICODE_LCD(TTF_Font *font, const Uint16 *text, SDL_Color fg, SDL_Color bg)
+{
+    return TTF_Render_Internal(font, (const char *)text, STR_UNICODE, fg, bg, RENDER_LCD);
+}
+
+SDL_Surface* TTF_RenderGlyph_LCD(TTF_Font *font, Uint16 ch, SDL_Color fg, SDL_Color bg)
+{
+    return TTF_RenderGlyph32_LCD(font, ch, fg, bg);
+}
+
+SDL_Surface* TTF_RenderGlyph32_LCD(TTF_Font *font, Uint32 ch, SDL_Color fg, SDL_Color bg)
+{
+    Uint8 utf8[7];
+
+    TTF_CHECK_POINTER(font, NULL);
+
+    if (!Char_to_UTF8(ch, utf8)) {
+        return NULL;
+    }
+
+    return TTF_RenderUTF8_LCD(font, (char *)utf8, fg, bg);
+}
+
 static SDL_bool CharacterIsDelimiter(Uint32 c)
 {
     if (c == ' ' || c == '\t' || c == '\r' || c == '\n') {
@@ -3299,6 +3540,11 @@ static SDL_Surface* TTF_Render_Wrapped_Internal(TTF_Font *font, const char *text
     TTF_CHECK_INITIALIZED(NULL);
     TTF_CHECK_POINTER(font, NULL);
     TTF_CHECK_POINTER(text, NULL);
+
+    if (render_mode == RENDER_LCD && !FT_IS_SCALABLE(font->face)) {
+        TTF_SetError("LCD rendering is not available for non-scalable font");
+        goto failure;
+    }
 
     /* Convert input string to default encoding UTF-8 */
     if (str_type == STR_TEXT) {
@@ -3422,8 +3668,10 @@ static SDL_Surface* TTF_Render_Wrapped_Internal(TTF_Font *font, const char *text
         textbuf = Create_Surface_Solid(width, height, fg, &color);
     } else if (render_mode == RENDER_SHADED) {
         textbuf = Create_Surface_Shaded(width, height, fg, bg, &color);
-    } else { /* render_mode == RENDER_BLENDED */
+    } else if (render_mode == RENDER_BLENDED) {
         textbuf = Create_Surface_Blended(width, height, fg, &color);
+    } else { /* render_mode == RENDER_LCD */
+        textbuf = Create_Surface_LCD(width, height, fg, bg, &color);
     }
 
     if (textbuf == NULL) {
@@ -3453,7 +3701,7 @@ static SDL_Surface* TTF_Render_Wrapped_Internal(TTF_Font *font, const char *text
         ystart += i * lineskip;
 
         /* Render one text line to textbuf at (xstart, ystart) */
-        if (Render_Line(render_mode, font->render_subpixel, font, textbuf, xstart, ystart, fg.a) < 0) {
+        if (Render_Line(render_mode, font->render_subpixel, font, textbuf, xstart, ystart, fg) < 0) {
             goto failure;
         }
 
@@ -3537,6 +3785,21 @@ SDL_Surface* TTF_RenderUTF8_Blended_Wrapped(TTF_Font *font, const char *text, SD
 SDL_Surface* TTF_RenderUNICODE_Blended_Wrapped(TTF_Font *font, const Uint16 *text, SDL_Color fg, Uint32 wrapLength)
 {
     return TTF_Render_Wrapped_Internal(font, (const char *)text, STR_UNICODE, fg, fg /* unused */, wrapLength, RENDER_BLENDED);
+}
+
+SDL_Surface* TTF_RenderText_LCD_Wrapped(TTF_Font *font, const char *text, SDL_Color fg, SDL_Color bg, Uint32 wrapLength)
+{
+    return TTF_Render_Wrapped_Internal(font, text, STR_TEXT, fg, bg, wrapLength, RENDER_LCD);
+}
+
+SDL_Surface* TTF_RenderUTF8_LCD_Wrapped(TTF_Font *font, const char *text, SDL_Color fg, SDL_Color bg, Uint32 wrapLength)
+{
+    return TTF_Render_Wrapped_Internal(font, text, STR_UTF8, fg, bg, wrapLength, RENDER_LCD);
+}
+
+SDL_Surface* TTF_RenderUNICODE_LCD_Wrapped(TTF_Font *font, const Uint16 *text, SDL_Color fg, SDL_Color bg, Uint32 wrapLength)
+{
+    return TTF_Render_Wrapped_Internal(font, (const char *)text, STR_UNICODE, fg, bg, wrapLength, RENDER_LCD);
 }
 
 SDL_Surface* TTF_RenderGlyph_Blended(TTF_Font *font, Uint16 ch, SDL_Color fg)

--- a/SDL_ttf.c
+++ b/SDL_ttf.c
@@ -2478,9 +2478,10 @@ static FT_Error Load_Glyph(TTF_Font *font, c_glyph *cached, int want, int transl
                                 d = 256 - (128 - s) * 2;
                             } else {
                                 d = 255;
+                                /* some glitch ?
                                 if (s == 255) {
                                     d = 0;
-                                }
+                                }*/
                             }
                             dstp[x] = d;
                         }

--- a/SDL_ttf.h
+++ b/SDL_ttf.h
@@ -317,6 +317,42 @@ extern DECLSPEC SDL_Surface * SDLCALL TTF_RenderGlyph_Blended(TTF_Font *font,
 extern DECLSPEC SDL_Surface * SDLCALL TTF_RenderGlyph32_Blended(TTF_Font *font,
                         Uint32 ch, SDL_Color fg);
 
+/* Create a 32-bit surface (SDL_PIXELFORMAT_ARGB8888) and render the given text
+   using FreeType LCD rendering, with the given font and colors.
+   This function returns the new surface, or NULL if there was an error.
+*/
+extern DECLSPEC SDL_Surface * SDLCALL TTF_RenderText_LCD(TTF_Font *font,
+                const char *text, SDL_Color fg, SDL_Color bg);
+extern DECLSPEC SDL_Surface * SDLCALL TTF_RenderUTF8_LCD(TTF_Font *font,
+                const char *text, SDL_Color fg, SDL_Color bg);
+extern DECLSPEC SDL_Surface * SDLCALL TTF_RenderUNICODE_LCD(TTF_Font *font,
+                const Uint16 *text, SDL_Color fg, SDL_Color bg);
+
+/* Create a 32-bit surface (SDL_PIXELFORMAT_ARGB8888) and render the given text
+   using FreeType LCD rendering, with the given font and colors.
+   Text is wrapped to multiple lines on line endings and on word boundaries
+   if it extends beyond wrapLength in pixels.
+   This function returns the new surface, or NULL if there was an error.
+*/
+extern DECLSPEC SDL_Surface * SDLCALL TTF_RenderText_LCD_Wrapped(TTF_Font *font,
+                const char *text, SDL_Color fg, SDL_Color bg, Uint32 wrapLength);
+extern DECLSPEC SDL_Surface * SDLCALL TTF_RenderUTF8_LCD_Wrapped(TTF_Font *font,
+                const char *text, SDL_Color fg, SDL_Color bg, Uint32 wrapLength);
+extern DECLSPEC SDL_Surface * SDLCALL TTF_RenderUNICODE_LCD_Wrapped(TTF_Font *font,
+                const Uint16 *text, SDL_Color fg, SDL_Color bg, Uint32 wrapLength);
+
+/* Create a 32-bit surface (SDL_PIXELFORMAT_ARGB8888) and render the given text
+   using FreeType LCD rendering, with the given font and colors.
+   The glyph is rendered without any padding or centering in the X
+   direction, and aligned normally in the Y direction.
+   This function returns the new surface, or NULL if there was an error.
+*/
+extern DECLSPEC SDL_Surface * SDLCALL TTF_RenderGlyph_LCD(TTF_Font *font,
+                Uint16 ch, SDL_Color fg, SDL_Color bg);
+extern DECLSPEC SDL_Surface * SDLCALL TTF_RenderGlyph32_LCD(TTF_Font *font,
+                Uint32 ch, SDL_Color fg, SDL_Color bg);
+
+
 /* For compatibility with previous versions, here are the old functions */
 #define TTF_RenderText(font, text, fg, bg)  \
     TTF_RenderText_Shaded(font, text, fg, bg)


### PR DESCRIPTION
As proposed in issue #131, add functions to use FreeType ClearType-style LCD rendering