### PR TITLE
Sized String Support = Optimizations

### DIFF
--- a/SDL_ttf.c
+++ b/SDL_ttf.c
@@ -117,7 +117,7 @@ int TTF_SetScript(int script) /* hb_script_t */
 #define HAVE_BLIT_GLYPH_32
 
 /* Use Duff's device to unroll loops */
-//#define USE_DUFFS_LOOP
+/*#define USE_DUFFS_LOOP*/
 
 #if defined(HAVE_SSE2_INTRINSICS)
 static SDL_INLINE int hasSSE2()
@@ -581,11 +581,11 @@ static SDL_INLINE void BG_Blended_Opaque_SSE(const TTF_Image *image, Uint32 *des
         /* *INDENT-OFF* */
         DUFFS_LOOP4(
             /* Read 16 Uint8 at once and put into 4 __m128i */
-            s  = _mm_loadu_si128(src);          // load unaligned
-            d0 = _mm_load_si128(dst);           // load
-            d1 = _mm_load_si128(dst + 1);       // load
-            d2 = _mm_load_si128(dst + 2);       // load
-            d3 = _mm_load_si128(dst + 3);       // load
+            s  = _mm_loadu_si128(src);          /* load unaligned */
+            d0 = _mm_load_si128(dst);           /* load */
+            d1 = _mm_load_si128(dst + 1);       /* load */
+            d2 = _mm_load_si128(dst + 2);       /* load */
+            d3 = _mm_load_si128(dst + 3);       /* load */
 
             L  = _mm_unpacklo_epi8(zero, s);
             H  = _mm_unpackhi_epi8(zero, s);
@@ -594,16 +594,16 @@ static SDL_INLINE void BG_Blended_Opaque_SSE(const TTF_Image *image, Uint32 *des
             s1 = _mm_unpackhi_epi8(zero, L);
             s2 = _mm_unpacklo_epi8(zero, H);
             s3 = _mm_unpackhi_epi8(zero, H);
-                                                // already shifted by 24
-            r0 = _mm_or_si128(d0, s0);          // or
-            r1 = _mm_or_si128(d1, s1);          // or
-            r2 = _mm_or_si128(d2, s2);          // or
-            r3 = _mm_or_si128(d3, s3);          // or
+                                                /* already shifted by 24 */
+            r0 = _mm_or_si128(d0, s0);          /* or */
+            r1 = _mm_or_si128(d1, s1);          /* or */
+            r2 = _mm_or_si128(d2, s2);          /* or */
+            r3 = _mm_or_si128(d3, s3);          /* or */
 
-            _mm_store_si128(dst, r0);           // store
-            _mm_store_si128(dst + 1, r1);       // store
-            _mm_store_si128(dst + 2, r2);       // store
-            _mm_store_si128(dst + 3, r3);       // store
+            _mm_store_si128(dst, r0);           /* store */
+            _mm_store_si128(dst + 1, r1);       /* store */
+            _mm_store_si128(dst + 2, r2);       /* store */
+            _mm_store_si128(dst + 3, r3);       /* store */
 
             dst += 4;
             src += 1;
@@ -630,48 +630,48 @@ static SDL_INLINE void BG_Blended_SSE(const TTF_Image *image, Uint32 *destinatio
         /* *INDENT-OFF* */
         DUFFS_LOOP4(
             /* Read 16 Uint8 at once and put into 4 __m128i */
-            s  = _mm_loadu_si128(src);          // load unaligned
-            d0 = _mm_load_si128(dst);           // load
-            d1 = _mm_load_si128(dst + 1);       // load
-            d2 = _mm_load_si128(dst + 2);       // load
-            d3 = _mm_load_si128(dst + 3);       // load
+            s  = _mm_loadu_si128(src);          /* load unaligned */
+            d0 = _mm_load_si128(dst);           /* load */
+            d1 = _mm_load_si128(dst + 1);       /* load */
+            d2 = _mm_load_si128(dst + 2);       /* load */
+            d3 = _mm_load_si128(dst + 3);       /* load */
 
-            L  = _mm_unpacklo_epi8(s, zero);    // interleave, no shifting
-            H  = _mm_unpackhi_epi8(s, zero);    // enough room to multiply
+            L  = _mm_unpacklo_epi8(s, zero);    /* interleave, no shifting */
+            H  = _mm_unpackhi_epi8(s, zero);    /* enough room to multiply */
 
             /* Apply: alpha_table[i] = ((i * fg.a / 255) << 24; */
             /* Divide by 255 is done as:    (x + 1 + (x >> 8)) >> 8 */
 
-            L  = _mm_mullo_epi16(L, alpha);     // x := i * fg.a
+            L  = _mm_mullo_epi16(L, alpha);     /* x := i * fg.a */
             H  = _mm_mullo_epi16(H, alpha);
 
-            Ls8 = _mm_srli_epi16(L, 8);         // x >> 8
+            Ls8 = _mm_srli_epi16(L, 8);         /* x >> 8 */
             Hs8 = _mm_srli_epi16(H, 8);
-            L = _mm_add_epi16(L, one);          // x + 1
+            L = _mm_add_epi16(L, one);          /* x + 1 */
             H = _mm_add_epi16(H, one);
-            L = _mm_add_epi16(L, Ls8);          // x + 1 + (x >> 8)
+            L = _mm_add_epi16(L, Ls8);          /* x + 1 + (x >> 8) */
             H = _mm_add_epi16(H, Hs8);
-            L = _mm_srli_epi16(L, 8);           // ((x + 1 + (x >> 8)) >> 8
+            L = _mm_srli_epi16(L, 8);           /* ((x + 1 + (x >> 8)) >> 8 */
             H = _mm_srli_epi16(H, 8);
 
-            L = _mm_slli_epi16(L, 8);           // shift << 8, so we're prepared
-            H = _mm_slli_epi16(H, 8);           // to have final format << 24
+            L = _mm_slli_epi16(L, 8);           /* shift << 8, so we're prepared */
+            H = _mm_slli_epi16(H, 8);           /* to have final format << 24 */
 
             s0 = _mm_unpacklo_epi8(zero, L);
             s1 = _mm_unpackhi_epi8(zero, L);
             s2 = _mm_unpacklo_epi8(zero, H);
             s3 = _mm_unpackhi_epi8(zero, H);
-                                                // already shifted by 24
+                                                /* already shifted by 24 */
 
-            r0 = _mm_or_si128(d0, s0);          // or
-            r1 = _mm_or_si128(d1, s1);          // or
-            r2 = _mm_or_si128(d2, s2);          // or
-            r3 = _mm_or_si128(d3, s3);          // or
+            r0 = _mm_or_si128(d0, s0);          /* or */
+            r1 = _mm_or_si128(d1, s1);          /* or */
+            r2 = _mm_or_si128(d2, s2);          /* or */
+            r3 = _mm_or_si128(d3, s3);          /* or */
 
-            _mm_store_si128(dst, r0);           // store
-            _mm_store_si128(dst + 1, r1);       // store
-            _mm_store_si128(dst + 2, r2);       // store
-            _mm_store_si128(dst + 3, r3);       // store
+            _mm_store_si128(dst, r0);           /* store */
+            _mm_store_si128(dst + 1, r1);       /* store */
+            _mm_store_si128(dst + 2, r2);       /* store */
+            _mm_store_si128(dst + 3, r3);       /* store */
 
             dst += 4;
             src += 1;
@@ -702,25 +702,25 @@ static SDL_INLINE void BG_Blended_Opaque_NEON(const TTF_Image *image, Uint32 *de
             /* Read 4 Uint32 and put 16 Uint8 into uint32x4x2_t (uint8x16x2_t)
              * takes advantage of vzipq_u8 which produces two lanes */
 
-            s   = vld1q_u32(src);               // load
-            d0  = vld1q_u32(dst);               // load
-            d1  = vld1q_u32(dst + 4);           // load
-            d2  = vld1q_u32(dst + 8);           // load
-            d3  = vld1q_u32(dst + 12);          // load
+            s   = vld1q_u32(src);               /* load */
+            d0  = vld1q_u32(dst);               /* load */
+            d1  = vld1q_u32(dst + 4);           /* load */
+            d2  = vld1q_u32(dst + 8);           /* load */
+            d3  = vld1q_u32(dst + 12);          /* load */
 
-            sx   = vzipq_u8(zero, s);           // interleave
-            sx01 = vzipq_u8(zero, sx.val[0]);   // interleave
-            sx23 = vzipq_u8(zero, sx.val[1]);   // interleave
-                                                // already shifted by 24
-            r0  = vorrq_u32(d0, sx01.val[0]);   // or
-            r1  = vorrq_u32(d1, sx01.val[1]);   // or
-            r2  = vorrq_u32(d2, sx23.val[0]);   // or
-            r3  = vorrq_u32(d3, sx23.val[1]);   // or
+            sx   = vzipq_u8(zero, s);           /* interleave */
+            sx01 = vzipq_u8(zero, sx.val[0]);   /* interleave */
+            sx23 = vzipq_u8(zero, sx.val[1]);   /* interleave */
+                                                /* already shifted by 24 */
+            r0  = vorrq_u32(d0, sx01.val[0]);   /* or */
+            r1  = vorrq_u32(d1, sx01.val[1]);   /* or */
+            r2  = vorrq_u32(d2, sx23.val[0]);   /* or */
+            r3  = vorrq_u32(d3, sx23.val[1]);   /* or */
 
-            vst1q_u32(dst, r0);                 // store
-            vst1q_u32(dst + 4, r1);             // store
-            vst1q_u32(dst + 8, r2);             // store
-            vst1q_u32(dst + 12, r3);            // store
+            vst1q_u32(dst, r0);                 /* store */
+            vst1q_u32(dst + 4, r1);             /* store */
+            vst1q_u32(dst + 8, r2);             /* store */
+            vst1q_u32(dst + 12, r3);            /* store */
 
             dst += 16;
             src += 4;
@@ -753,49 +753,49 @@ static SDL_INLINE void BG_Blended_NEON(const TTF_Image *image, Uint32 *destinati
             /* Read 4 Uint32 and put 16 Uint8 into uint32x4x2_t (uint8x16x2_t)
              * takes advantage of vzipq_u8 which produces two lanes */
 
-            s  = vld1q_u32(src);                        // load
-            d0 = vld1q_u32(dst);                        // load
-            d1 = vld1q_u32(dst + 4);                    // load
-            d2 = vld1q_u32(dst + 8);                    // load
-            d3 = vld1q_u32(dst + 12);                   // load
+            s  = vld1q_u32(src);                        /* load */
+            d0 = vld1q_u32(dst);                        /* load */
+            d1 = vld1q_u32(dst + 4);                    /* load */
+            d2 = vld1q_u32(dst + 8);                    /* load */
+            d3 = vld1q_u32(dst + 12);                   /* load */
 
-            sx = vzipq_u8(s, zero);                     // interleave, no shifting
-                                                        // enough room to multiply
+            sx = vzipq_u8(s, zero);                     /* interleave, no shifting */
+                                                        /* enough room to multiply */
 
             /* Apply: alpha_table[i] = ((i * fg.a / 255) << 24; */
             /* Divide by 255 is done as:    (x + 1 + (x >> 8)) >> 8 */
 
-            sx.val[0] = vmulq_u16(sx.val[0], alpha);    // x := i * fg.a
+            sx.val[0] = vmulq_u16(sx.val[0], alpha);    /* x := i * fg.a */
             sx.val[1] = vmulq_u16(sx.val[1], alpha);
 
-            Ls8 = vshrq_n_u16(sx.val[0], 8);            // x >> 8
+            Ls8 = vshrq_n_u16(sx.val[0], 8);            /* x >> 8 */
             Hs8 = vshrq_n_u16(sx.val[1], 8);
 
-            sx.val[0] = vaddq_u16(sx.val[0], one);      // x + 1
+            sx.val[0] = vaddq_u16(sx.val[0], one);      /* x + 1 */
             sx.val[1] = vaddq_u16(sx.val[1], one);
 
-            sx.val[0] = vaddq_u16(sx.val[0], Ls8);      // x + 1 + (x >> 8)
+            sx.val[0] = vaddq_u16(sx.val[0], Ls8);      /* x + 1 + (x >> 8) */
             sx.val[1] = vaddq_u16(sx.val[1], Hs8);
 
-            sx.val[0] = vshrq_n_u16(sx.val[0], 8);      // ((x + 1 + (x >> 8)) >> 8
+            sx.val[0] = vshrq_n_u16(sx.val[0], 8);      /* ((x + 1 + (x >> 8)) >> 8 */
             sx.val[1] = vshrq_n_u16(sx.val[1], 8);
 
-            sx.val[0] = vshlq_n_u16(sx.val[0], 8);      // shift << 8, so we're prepared
-            sx.val[1] = vshlq_n_u16(sx.val[1], 8);      // to have final format << 24
+            sx.val[0] = vshlq_n_u16(sx.val[0], 8);      /* shift << 8, so we're prepared */
+            sx.val[1] = vshlq_n_u16(sx.val[1], 8);      /* to have final format << 24 */
 
-            sx01 = vzipq_u8(zero, sx.val[0]);           // interleave
-            sx23 = vzipq_u8(zero, sx.val[1]);           // interleave
-                                                        // already shifted by 24
+            sx01 = vzipq_u8(zero, sx.val[0]);           /* interleave */
+            sx23 = vzipq_u8(zero, sx.val[1]);           /* interleave */
+                                                        /* already shifted by 24 */
 
-            r0  = vorrq_u32(d0, sx01.val[0]);           // or
-            r1  = vorrq_u32(d1, sx01.val[1]);           // or
-            r2  = vorrq_u32(d2, sx23.val[0]);           // or
-            r3  = vorrq_u32(d3, sx23.val[1]);           // or
+            r0  = vorrq_u32(d0, sx01.val[0]);           /* or */
+            r1  = vorrq_u32(d1, sx01.val[1]);           /* or */
+            r2  = vorrq_u32(d2, sx23.val[0]);           /* or */
+            r3  = vorrq_u32(d3, sx23.val[1]);           /* or */
 
-            vst1q_u32(dst, r0);                         // store
-            vst1q_u32(dst + 4, r1);                     // store
-            vst1q_u32(dst + 8, r2);                     // store
-            vst1q_u32(dst + 12, r3);                    // store
+            vst1q_u32(dst, r0);                         /* store */
+            vst1q_u32(dst + 4, r1);                     /* store */
+            vst1q_u32(dst + 8, r2);                     /* store */
+            vst1q_u32(dst + 12, r3);                    /* store */
 
             dst += 16;
             src += 4;
@@ -876,10 +876,10 @@ static SDL_INLINE void BG_SSE(const TTF_Image *image, Uint8 *destination, Sint32
     while (height--) {
         /* *INDENT-OFF* */
         DUFFS_LOOP4(
-            s = _mm_loadu_si128(src);   // load unaligned
-            d = _mm_load_si128(dst);    // load
-            r = _mm_or_si128(d, s);     // or
-            _mm_store_si128(dst, r);    // store
+            s = _mm_loadu_si128(src);   /* load unaligned */
+            d = _mm_load_si128(dst);    /* load */
+            r = _mm_or_si128(d, s);     /* or */
+            _mm_store_si128(dst, r);    /* store */
             src += 1;
             dst += 1;
         , width);
@@ -903,10 +903,10 @@ static SDL_INLINE void BG_NEON(const TTF_Image *image, Uint8 *destination, Sint3
     while (height--) {
         /* *INDENT-OFF* */
         DUFFS_LOOP4(
-            s = vld1q_u8(src);  // load
-            d = vld1q_u8(dst);  // load
-            r = vorrq_u8(d, s); // or
-            vst1q_u8(dst, r);   // store
+            s = vld1q_u8(src);  /* load */
+            d = vld1q_u8(dst);  /* load */
+            r = vorrq_u8(d, s); /* or */
+            vst1q_u8(dst, r);   /* store */
             src += 16;
             dst += 16;
         , width);
@@ -2337,7 +2337,7 @@ static FT_Error Load_Glyph(TTF_Font *font, c_glyph *cached, int want, int transl
                     if (ft_render_mode != FT_RENDER_MODE_SDF) {
                         SDL_memcpy(dstp, srcp, src->width);
                     } else {
-                        int x;
+                        unsigned int x;
                         for (x = 0; x < src->width; x++) {
                             Uint8 s = srcp[x];
                             Uint8 d;
@@ -2888,9 +2888,6 @@ static SDL_INLINE Uint32 TTF_StringView_SplitChar(TTF_StringView *rest)
         const char* p = (const char*)rest->data;
         Uint32 c = UTF8_getch(p, rest->size, &inc);
 
-        //if(c == UNKNOWN_UNICODE) /* try to display one <?> character representing an invalid byte */
-        //    inc = 1;
-
         rest->data = (const void*)(p+inc);
         rest->size -= inc;
 
@@ -3045,7 +3042,6 @@ static int TTF_Size_Internal(TTF_Font *font,
     hb_glyph_position_t *hb_glyph_position;
     int y = 0;
 #else
-    size_t textlen;
     int skip_first = 1;
     FT_UInt prev_index = 0;
     FT_Pos  prev_delta = 0;
@@ -3579,6 +3575,7 @@ SDL_bool TTF_SplitWrap_Lines_Internal(TTF_Font *font, TTF_StringView **p_lines, 
         size_t save_textlen = (size_t)(-1);
         const void *save_text  = NULL;
         const void *line_start = text.data;
+        TTF_StringView *line;
 
         if (*p_numLines >= maxNumLines) {
             TTF_StringView *new_lines;
@@ -3595,7 +3592,7 @@ SDL_bool TTF_SplitWrap_Lines_Internal(TTF_Font *font, TTF_StringView **p_lines, 
             *p_lines = new_lines;
         }
 
-        TTF_StringView *line = &(*p_lines)[*p_numLines];
+        line = &(*p_lines)[*p_numLines];
         *line = text;
         ++*p_numLines;
 

--- a/SDL_ttf.c
+++ b/SDL_ttf.c
@@ -2826,7 +2826,7 @@ static TTF_StringView TTF_MakeStringView_TEXT(const char *text) {
     return sv;
 }
 
-static TTF_StringView TTF_MakeStringView_TEXT_N(const char *text, size_t size) {
+static TTF_StringView TTF_MakeStringView_TEXT_SZ(const char *text, size_t size) {
     TTF_StringView sv;
     sv.data = text;
     sv.size = size;
@@ -2842,7 +2842,7 @@ static TTF_StringView TTF_MakeStringView_UNICODE(const Uint16 *text) {
     return sv;
 }
 
-static TTF_StringView TTF_MakeStringView_UNICODE_N(const Uint16 *text, size_t size) {
+static TTF_StringView TTF_MakeStringView_UNICODE_SZ(const Uint16 *text, size_t size) {
     TTF_StringView sv;
     sv.data = text;
     sv.size = size;
@@ -3279,6 +3279,21 @@ int TTF_SizeUNICODE(TTF_Font *font, const Uint16 *text, int *w, int *h)
     return TTF_Size_Internal(font, TTF_MakeStringView_UNICODE(text), NULL, w, h, NULL, NULL, NO_MEASUREMENT);
 }
 
+int TTF_SizeText_SZ(TTF_Font *font, const char *text, size_t text_size, int *w, int *h)
+{
+    return TTF_Size_Internal(font, TTF_MakeStringView_TEXT_SZ(text, text_size), NULL, w, h, NULL, NULL, NO_MEASUREMENT);
+}
+
+int TTF_SizeUTF8_SZ(TTF_Font *font, const char *text, size_t text_size, int *w, int *h)
+{
+    return TTF_Size_Internal(font, TTF_MakeStringView_UTF8_SZ(text, text_size), NULL, w, h, NULL, NULL, NO_MEASUREMENT);
+}
+
+int TTF_SizeUNICODE_SZ(TTF_Font *font, const Uint16 *text, size_t text_size, int *w, int *h)
+{
+    return TTF_Size_Internal(font, TTF_MakeStringView_UNICODE_SZ(text, text_size), NULL, w, h, NULL, NULL, NO_MEASUREMENT);
+}
+
 static SDL_INLINE int TTF_Measure_Internal(TTF_Font *font, TTF_StringView text, int width, int *extent, int *count)
 {
     return TTF_Size_Internal(font, text, NULL, NULL, NULL, NULL, NULL, width, extent, count);
@@ -3300,6 +3315,21 @@ int TTF_MeasureUNICODE(TTF_Font *font, const Uint16 *text, int width, int *exten
 {
     TTF_CHECK_POINTER(text, -1);
     return TTF_Measure_Internal(font, TTF_MakeStringView_UNICODE(text), width, extent, count);
+}
+
+int TTF_MeasureText_SZ(TTF_Font *font, const char *text, size_t text_size, int width, int *extent, int *count)
+{
+    return TTF_Measure_Internal(font, TTF_MakeStringView_TEXT_SZ(text, text_size), width, extent, count);
+}
+
+int TTF_MeasureUTF8_SZ(TTF_Font *font, const char *text, size_t text_size, int width, int *extent, int *count)
+{
+    return TTF_Measure_Internal(font, TTF_MakeStringView_UTF8_SZ(text, text_size), width, extent, count);
+}
+
+int TTF_MeasureUNICODE_SZ(TTF_Font *font, const Uint16 *text, size_t text_size, int width, int *extent, int *count)
+{
+    return TTF_Measure_Internal(font, TTF_MakeStringView_UNICODE_SZ(text, text_size), width, extent, count);
 }
 
 static SDL_Surface* TTF_Render_Internal(TTF_Font *font, TTF_StringView text,
@@ -3394,6 +3424,24 @@ SDL_Surface* TTF_RenderUNICODE_Solid(TTF_Font *font, const Uint16 *text, SDL_Col
     return TTF_Render_Internal(font, TTF_MakeStringView_UNICODE(text), fg, fg /* unused */, RENDER_SOLID);
 }
 
+SDL_Surface* TTF_RenderText_Solid_SZ(TTF_Font *font, const char *text, size_t text_size, SDL_Color fg)
+{
+    TTF_CHECK_POINTER(text, NULL);
+    return TTF_Render_Internal(font, TTF_MakeStringView_TEXT_SZ(text, text_size), fg, fg /* unused */, RENDER_SOLID);
+}
+
+SDL_Surface* TTF_RenderUTF8_Solid_SZ(TTF_Font *font, const char *text, size_t text_size, SDL_Color fg)
+{
+    TTF_CHECK_POINTER(text, NULL);
+    return TTF_Render_Internal(font, TTF_MakeStringView_UTF8_SZ(text, text_size), fg, fg /* unused */, RENDER_SOLID);
+}
+
+SDL_Surface* TTF_RenderUNICODE_Solid_SZ(TTF_Font *font, const Uint16 *text, size_t text_size, SDL_Color fg)
+{
+    TTF_CHECK_POINTER(text, NULL);
+    return TTF_Render_Internal(font, TTF_MakeStringView_UNICODE_SZ(text, text_size), fg, fg /* unused */, RENDER_SOLID);
+}
+
 SDL_Surface* TTF_RenderGlyph_Solid(TTF_Font *font, Uint16 ch, SDL_Color fg)
 {
     return TTF_RenderGlyph32_Solid(font, ch, fg);
@@ -3428,6 +3476,24 @@ SDL_Surface* TTF_RenderUNICODE_Shaded(TTF_Font *font, const Uint16 *text, SDL_Co
 {
     TTF_CHECK_POINTER(text, NULL);
     return TTF_Render_Internal(font, TTF_MakeStringView_UNICODE(text), fg, bg, RENDER_SHADED);
+}
+
+SDL_Surface* TTF_RenderText_Shaded_SZ(TTF_Font *font, const char *text, size_t text_size, SDL_Color fg, SDL_Color bg)
+{
+    TTF_CHECK_POINTER(text, NULL);
+    return TTF_Render_Internal(font, TTF_MakeStringView_TEXT_SZ(text, text_size), fg, bg, RENDER_SHADED);
+}
+
+SDL_Surface* TTF_RenderUTF8_Shaded_SZ(TTF_Font *font, const char *text, size_t text_size, SDL_Color fg, SDL_Color bg)
+{
+    TTF_CHECK_POINTER(text, NULL);
+    return TTF_Render_Internal(font, TTF_MakeStringView_UTF8_SZ(text, text_size), fg, bg, RENDER_SHADED);
+}
+
+SDL_Surface* TTF_RenderUNICODE_Shaded_SZ(TTF_Font *font, const Uint16 *text, size_t text_size, SDL_Color fg, SDL_Color bg)
+{
+    TTF_CHECK_POINTER(text, NULL);
+    return TTF_Render_Internal(font, TTF_MakeStringView_UNICODE_SZ(text, text_size), fg, bg, RENDER_SHADED);
 }
 
 SDL_Surface* TTF_RenderGlyph_Shaded(TTF_Font *font, Uint16 ch, SDL_Color fg, SDL_Color bg)
@@ -3466,6 +3532,24 @@ SDL_Surface* TTF_RenderUNICODE_Blended(TTF_Font *font, const Uint16 *text, SDL_C
     return TTF_Render_Internal(font, TTF_MakeStringView_UNICODE(text), fg, fg /* unused */, RENDER_BLENDED);
 }
 
+SDL_Surface* TTF_RenderText_Blended_SZ(TTF_Font *font, const char *text, size_t text_size, SDL_Color fg)
+{
+    TTF_CHECK_POINTER(text, NULL);
+    return TTF_Render_Internal(font, TTF_MakeStringView_TEXT_SZ(text, text_size), fg, fg /* unused */, RENDER_BLENDED);
+}
+
+SDL_Surface* TTF_RenderUTF8_Blended_SZ(TTF_Font *font, const char *text, size_t text_size, SDL_Color fg)
+{
+    TTF_CHECK_POINTER(text, NULL);
+    return TTF_Render_Internal(font, TTF_MakeStringView_UTF8_SZ(text, text_size), fg, fg /* unused */, RENDER_BLENDED);
+}
+
+SDL_Surface* TTF_RenderUNICODE_Blended_SZ(TTF_Font *font, const Uint16 *text, size_t text_size, SDL_Color fg)
+{
+    TTF_CHECK_POINTER(text, NULL);
+    return TTF_Render_Internal(font, TTF_MakeStringView_UNICODE_SZ(text, text_size), fg, fg /* unused */, RENDER_BLENDED);
+}
+
 SDL_Surface* TTF_RenderGlyph_Blended(TTF_Font *font, Uint16 ch, SDL_Color fg)
 {
     return TTF_RenderGlyph32_Blended(font, ch, fg);
@@ -3497,13 +3581,13 @@ SDL_bool TTF_SplitWrap_Lines_Internal(TTF_Font *font, TTF_StringView **p_lines, 
         const void *line_start = text.data;
 
         if (*p_numLines >= maxNumLines) {
-            TTF_StringView **new_lines;
+            TTF_StringView *new_lines;
             if (wrapLength == 0) {
                 maxNumLines += 32;
             } else {
                 maxNumLines += (*p_width / wrapLength) + 1;
             }
-            new_lines = (TTF_StringView **)SDL_realloc(*p_lines, maxNumLines * sizeof (*p_lines));
+            new_lines = (TTF_StringView *)SDL_realloc(*p_lines, maxNumLines * sizeof (*p_lines));
             if (new_lines == NULL) {
                 SDL_OutOfMemory();
                 return SDL_FALSE;
@@ -3590,38 +3674,6 @@ static SDL_Surface* TTF_Render_Wrapped_Internal(TTF_Font *font, TTF_StringView t
 
     TTF_CHECK_INITIALIZED(NULL);
     TTF_CHECK_POINTER(font, NULL);
-
-#if 0
-    /* Convert input string to default encoding UTF-8 */
-    if (str_type == STR_TEXT) {
-        utf8_alloc = SDL_stack_alloc(Uint8, LATIN1_to_UTF8_len(text));
-        if (utf8_alloc == NULL) {
-            SDL_OutOfMemory();
-            goto failure;
-        }
-        LATIN1_to_UTF8(text, utf8_alloc);
-        text_cpy = (char *)utf8_alloc;
-    } else if (str_type == STR_UNICODE) {
-        const Uint16 *text16 = (const Uint16 *) text;
-        utf8_alloc = SDL_stack_alloc(Uint8, UCS2_to_UTF8_len(text16));
-        if (utf8_alloc == NULL) {
-            SDL_OutOfMemory();
-            goto failure;
-        }
-        UCS2_to_UTF8(text16, utf8_alloc);
-        text_cpy = (char *)utf8_alloc;
-    } else {
-        /* Use a copy anyway */
-        size_t str_len = SDL_strlen(text);
-        utf8_alloc = SDL_stack_alloc(Uint8, str_len + 1);
-        if (utf8_alloc == NULL) {
-            SDL_OutOfMemory();
-            goto failure;
-        }
-        SDL_memcpy(utf8_alloc, text, str_len + 1);
-        text_cpy = (char *)utf8_alloc;
-    }
-#endif
 
     /* Get the dimensions of the text surface */
     if ((TTF_Size_Internal(font, text, NULL, &width, &height, NULL, NULL, NO_MEASUREMENT) < 0) || !width) {
@@ -3764,6 +3816,24 @@ SDL_Surface* TTF_RenderUNICODE_Solid_Wrapped(TTF_Font *font, const Uint16 *text,
     return TTF_Render_Wrapped_Internal(font, TTF_MakeStringView_UNICODE(text), fg, fg /* unused */, wrapLength, RENDER_SOLID);
 }
 
+SDL_Surface* TTF_RenderText_Solid_Wrapped_SZ(TTF_Font *font, const char *text, size_t text_size, SDL_Color fg, Uint32 wrapLength)
+{
+    TTF_CHECK_POINTER(text, NULL);
+    return TTF_Render_Wrapped_Internal(font, TTF_MakeStringView_TEXT_SZ(text, text_size), fg, fg /* unused */, wrapLength, RENDER_SOLID);
+}
+
+SDL_Surface* TTF_RenderUTF8_Solid_Wrapped_SZ(TTF_Font *font, const char *text, size_t text_size, SDL_Color fg, Uint32 wrapLength)
+{
+    TTF_CHECK_POINTER(text, NULL);
+    return TTF_Render_Wrapped_Internal(font, TTF_MakeStringView_UTF8_SZ(text, text_size), fg, fg /* unused */, wrapLength, RENDER_SOLID);
+}
+
+SDL_Surface* TTF_RenderUNICODE_Solid_Wrapped_SZ(TTF_Font *font, const Uint16 *text, size_t text_size, SDL_Color fg, Uint32 wrapLength)
+{
+    TTF_CHECK_POINTER(text, NULL);
+    return TTF_Render_Wrapped_Internal(font, TTF_MakeStringView_UNICODE_SZ(text, text_size), fg, fg /* unused */, wrapLength, RENDER_SOLID);
+}
+
 SDL_Surface* TTF_RenderText_Shaded_Wrapped(TTF_Font *font, const char *text, SDL_Color fg, SDL_Color bg, Uint32 wrapLength)
 {
     TTF_CHECK_POINTER(text, NULL);
@@ -3782,6 +3852,24 @@ SDL_Surface* TTF_RenderUNICODE_Shaded_Wrapped(TTF_Font *font, const Uint16 *text
     return TTF_Render_Wrapped_Internal(font, TTF_MakeStringView_UNICODE(text), fg, bg, wrapLength, RENDER_SHADED);
 }
 
+SDL_Surface* TTF_RenderText_Shaded_Wrapped_SZ(TTF_Font *font, const char *text, size_t text_size, SDL_Color fg, SDL_Color bg, Uint32 wrapLength)
+{
+    TTF_CHECK_POINTER(text, NULL);
+    return TTF_Render_Wrapped_Internal(font, TTF_MakeStringView_TEXT_SZ(text, text_size), fg, bg, wrapLength, RENDER_SHADED);
+}
+
+SDL_Surface* TTF_RenderUTF8_Shaded_Wrapped_SZ(TTF_Font *font, const char *text, size_t text_size, SDL_Color fg, SDL_Color bg, Uint32 wrapLength)
+{
+    TTF_CHECK_POINTER(text, NULL);
+    return TTF_Render_Wrapped_Internal(font, TTF_MakeStringView_UTF8_SZ(text, text_size), fg, bg, wrapLength, RENDER_SHADED);
+}
+
+SDL_Surface* TTF_RenderUNICODE_Shaded_Wrapped_SZ(TTF_Font *font, const Uint16 *text, size_t text_size, SDL_Color fg, SDL_Color bg, Uint32 wrapLength)
+{
+    TTF_CHECK_POINTER(text, NULL);
+    return TTF_Render_Wrapped_Internal(font, TTF_MakeStringView_UNICODE_SZ(text, text_size), fg, bg, wrapLength, RENDER_SHADED);
+}
+
 SDL_Surface* TTF_RenderText_Blended_Wrapped(TTF_Font *font, const char *text, SDL_Color fg, Uint32 wrapLength)
 {
     TTF_CHECK_POINTER(text, NULL);
@@ -3798,6 +3886,24 @@ SDL_Surface* TTF_RenderUNICODE_Blended_Wrapped(TTF_Font *font, const Uint16 *tex
 {
     TTF_CHECK_POINTER(text, NULL);
     return TTF_Render_Wrapped_Internal(font, TTF_MakeStringView_UNICODE(text), fg, fg /* unused */, wrapLength, RENDER_BLENDED);
+}
+
+SDL_Surface* TTF_RenderText_Blended_Wrapped_SZ(TTF_Font *font, const char *text, size_t text_size, SDL_Color fg, Uint32 wrapLength)
+{
+    TTF_CHECK_POINTER(text, NULL);
+    return TTF_Render_Wrapped_Internal(font, TTF_MakeStringView_TEXT_SZ(text, text_size), fg, fg /* unused */, wrapLength, RENDER_BLENDED);
+}
+
+SDL_Surface* TTF_RenderUTF8_Blended_Wrapped_SZ(TTF_Font *font, const char *text, size_t text_size, SDL_Color fg, Uint32 wrapLength)
+{
+    TTF_CHECK_POINTER(text, NULL);
+    return TTF_Render_Wrapped_Internal(font, TTF_MakeStringView_UTF8_SZ(text, text_size), fg, fg /* unused */, wrapLength, RENDER_BLENDED);
+}
+
+SDL_Surface* TTF_RenderUNICODE_Blended_Wrapped_SZ(TTF_Font *font, const Uint16 *text, size_t text_size, SDL_Color fg, Uint32 wrapLength)
+{
+    TTF_CHECK_POINTER(text, NULL);
+    return TTF_Render_Wrapped_Internal(font, TTF_MakeStringView_UNICODE_SZ(text, text_size), fg, fg /* unused */, wrapLength, RENDER_BLENDED);
 }
 
 void TTF_SetFontStyle(TTF_Font *font, int style)

--- a/SDL_ttf.h
+++ b/SDL_ttf.h
@@ -200,6 +200,10 @@ extern DECLSPEC int SDLCALL TTF_SizeText(TTF_Font *font, const char *text, int *
 extern DECLSPEC int SDLCALL TTF_SizeUTF8(TTF_Font *font, const char *text, int *w, int *h);
 extern DECLSPEC int SDLCALL TTF_SizeUNICODE(TTF_Font *font, const Uint16 *text, int *w, int *h);
 
+extern DECLSPEC int SDLCALL TTF_SizeText_SZ(TTF_Font *font, const char *text, size_t text_size, int *w, int *h);
+extern DECLSPEC int SDLCALL TTF_SizeUTF8_SZ(TTF_Font *font, const char *text, size_t text_size, int *w, int *h);
+extern DECLSPEC int SDLCALL TTF_SizeUNICODE_SZ(TTF_Font *font, const Uint16 *text, size_t text_size, int *w, int *h);
+
 /* Get the measurement string of text without rendering
    e.g. the number of characters that can be rendered before reaching 'measure_width'
 
@@ -213,6 +217,10 @@ extern DECLSPEC int SDLCALL TTF_MeasureText(TTF_Font *font, const char *text, in
 extern DECLSPEC int SDLCALL TTF_MeasureUTF8(TTF_Font *font, const char *text, int measure_width, int *extent, int *count);
 extern DECLSPEC int SDLCALL TTF_MeasureUNICODE(TTF_Font *font, const Uint16 *text, int measure_width, int *extent, int *count);
 
+extern DECLSPEC int SDLCALL TTF_MeasureText_SZ(TTF_Font *font, const char *text, size_t text_size, int measure_width, int *extent, int *count);
+extern DECLSPEC int SDLCALL TTF_MeasureUTF8_SZ(TTF_Font *font, const char *text, size_t text_size, int measure_width, int *extent, int *count);
+extern DECLSPEC int SDLCALL TTF_MeasureUNICODE_SZ(TTF_Font *font, const Uint16 *text, size_t text_size, int measure_width, int *extent, int *count);
+
 /* Create an 8-bit palettized surface and render the given text at
    fast quality with the given font and color.  The 0 pixel is the
    colorkey, giving a transparent background, and the 1 pixel is set
@@ -225,6 +233,13 @@ extern DECLSPEC SDL_Surface * SDLCALL TTF_RenderUTF8_Solid(TTF_Font *font,
                 const char *text, SDL_Color fg);
 extern DECLSPEC SDL_Surface * SDLCALL TTF_RenderUNICODE_Solid(TTF_Font *font,
                 const Uint16 *text, SDL_Color fg);
+
+extern DECLSPEC SDL_Surface * SDLCALL TTF_RenderText_Solid_SZ(TTF_Font *font,
+                const char *text, size_t text_size, SDL_Color fg);
+extern DECLSPEC SDL_Surface * SDLCALL TTF_RenderUTF8_Solid_SZ(TTF_Font *font,
+                const char *text, size_t text_size, SDL_Color fg);
+extern DECLSPEC SDL_Surface * SDLCALL TTF_RenderUNICODE_Solid_SZ(TTF_Font *font,
+                const Uint16 *text, size_t text_size, SDL_Color fg);
 
 /* Create an 8-bit palettized surface and render the given text at
    fast quality with the given font and color.  The 0 pixel is the
@@ -241,6 +256,13 @@ extern DECLSPEC SDL_Surface * SDLCALL TTF_RenderUTF8_Solid_Wrapped(TTF_Font *fon
                 const char *text, SDL_Color fg, Uint32 wrapLength);
 extern DECLSPEC SDL_Surface * SDLCALL TTF_RenderUNICODE_Solid_Wrapped(TTF_Font *font,
                 const Uint16 *text, SDL_Color fg, Uint32 wrapLength);
+
+extern DECLSPEC SDL_Surface * SDLCALL TTF_RenderText_Solid_Wrapped_SZ(TTF_Font *font,
+                const char *text, size_t text_size, SDL_Color fg, Uint32 wrapLength);
+extern DECLSPEC SDL_Surface * SDLCALL TTF_RenderUTF8_Solid_Wrapped_SZ(TTF_Font *font,
+                const char *text, size_t text_size, SDL_Color fg, Uint32 wrapLength);
+extern DECLSPEC SDL_Surface * SDLCALL TTF_RenderUNICODE_Solid_Wrapped_SZ(TTF_Font *font,
+                const Uint16 *text, size_t text_size, SDL_Color fg, Uint32 wrapLength);
 
 /* Create an 8-bit palettized surface and render the given glyph at
    fast quality with the given font and color.  The 0 pixel is the
@@ -266,6 +288,13 @@ extern DECLSPEC SDL_Surface * SDLCALL TTF_RenderUTF8_Shaded(TTF_Font *font,
 extern DECLSPEC SDL_Surface * SDLCALL TTF_RenderUNICODE_Shaded(TTF_Font *font,
                 const Uint16 *text, SDL_Color fg, SDL_Color bg);
 
+extern DECLSPEC SDL_Surface * SDLCALL TTF_RenderText_Shaded_SZ(TTF_Font *font,
+                const char *text, size_t text_size, SDL_Color fg, SDL_Color bg);
+extern DECLSPEC SDL_Surface * SDLCALL TTF_RenderUTF8_Shaded_SZ(TTF_Font *font,
+                const char *text, size_t text_size, SDL_Color fg, SDL_Color bg);
+extern DECLSPEC SDL_Surface * SDLCALL TTF_RenderUNICODE_Shaded_SZ(TTF_Font *font,
+                const Uint16 *text, size_t text_size, SDL_Color fg, SDL_Color bg);
+
 /* Create an 8-bit palettized surface and render the given text at
    high quality with the given font and colors.  The 0 pixel is background,
    while other pixels have varying degrees of the foreground color.
@@ -280,6 +309,13 @@ extern DECLSPEC SDL_Surface * SDLCALL TTF_RenderUTF8_Shaded_Wrapped(TTF_Font *fo
                 const char *text, SDL_Color fg, SDL_Color bg, Uint32 wrapLength);
 extern DECLSPEC SDL_Surface * SDLCALL TTF_RenderUNICODE_Shaded_Wrapped(TTF_Font *font,
                 const Uint16 *text, SDL_Color fg, SDL_Color bg, Uint32 wrapLength);
+
+extern DECLSPEC SDL_Surface * SDLCALL TTF_RenderText_Shaded_Wrapped_SZ(TTF_Font *font,
+                const char *text, size_t text_size, SDL_Color fg, SDL_Color bg, Uint32 wrapLength);
+extern DECLSPEC SDL_Surface * SDLCALL TTF_RenderUTF8_Shaded_Wrapped_SZ(TTF_Font *font,
+                const char *text, size_t text_size, SDL_Color fg, SDL_Color bg, Uint32 wrapLength);
+extern DECLSPEC SDL_Surface * SDLCALL TTF_RenderUNICODE_Shaded_Wrapped_SZ(TTF_Font *font,
+                const Uint16 *text, size_t text_size, SDL_Color fg, SDL_Color bg, Uint32 wrapLength);
 
 /* Create an 8-bit palettized surface and render the given glyph at
    high quality with the given font and colors.  The 0 pixel is background,
@@ -304,6 +340,13 @@ extern DECLSPEC SDL_Surface * SDLCALL TTF_RenderUTF8_Blended(TTF_Font *font,
 extern DECLSPEC SDL_Surface * SDLCALL TTF_RenderUNICODE_Blended(TTF_Font *font,
                 const Uint16 *text, SDL_Color fg);
 
+extern DECLSPEC SDL_Surface * SDLCALL TTF_RenderText_Blended_SZ(TTF_Font *font,
+                const char *text, size_t text_size, SDL_Color fg);
+extern DECLSPEC SDL_Surface * SDLCALL TTF_RenderUTF8_Blended_SZ(TTF_Font *font,
+                const char *text, size_t text_size, SDL_Color fg);
+extern DECLSPEC SDL_Surface * SDLCALL TTF_RenderUNICODE_Blended_SZ(TTF_Font *font,
+                const Uint16 *text, size_t text_size, SDL_Color fg);
+
 
 /* Create a 32-bit ARGB surface and render the given text at high quality,
    using alpha blending to dither the font with the given color.
@@ -318,6 +361,13 @@ extern DECLSPEC SDL_Surface * SDLCALL TTF_RenderUTF8_Blended_Wrapped(TTF_Font *f
                 const char *text, SDL_Color fg, Uint32 wrapLength);
 extern DECLSPEC SDL_Surface * SDLCALL TTF_RenderUNICODE_Blended_Wrapped(TTF_Font *font,
                 const Uint16 *text, SDL_Color fg, Uint32 wrapLength);
+
+extern DECLSPEC SDL_Surface * SDLCALL TTF_RenderText_Blended_Wrapped_SZ(TTF_Font *font,
+                const char *text, size_t text_size, SDL_Color fg, Uint32 wrapLength);
+extern DECLSPEC SDL_Surface * SDLCALL TTF_RenderUTF8_Blended_Wrapped_SZ(TTF_Font *font,
+                const char *text, size_t text_size, SDL_Color fg, Uint32 wrapLength);
+extern DECLSPEC SDL_Surface * SDLCALL TTF_RenderUNICODE_Blended_Wrapped_SZ(TTF_Font *font,
+                const Uint16 *text, size_t text_size, SDL_Color fg, Uint32 wrapLength);
 
 /* Create a 32-bit ARGB surface and render the given glyph at high quality,
    using alpha blending to dither the font with the given color.

--- a/showfont.c
+++ b/showfont.c
@@ -278,12 +278,13 @@ int main(int argc, char *argv[])
 
     /* Render and center the message */
     if (argc >= 2) {
-        if(wrap) // concatenate message
+        if(wrap) /* concatenate message */
         {
             size_t start = 0;
             size_t rest_bytes = sizeof(string);
+            int i;
             
-            for(int i = 2; i < argc && rest_bytes > 0; ++i)
+            for(i = 2; i < argc && rest_bytes > 0; ++i)
             {
                 int cnt = SDL_snprintf(string+start, rest_bytes, "%s%s", (i == 2 ? "" : "\n"), argv[i]);
                 if(cnt <= 0) break;


### PR DESCRIPTION
Added sized string support, such that it can be used for example with C++ `std::string_view`. Introducing an internal `StringView` struct, that contains a pointer, the size of the string and the encoding.

This allows to reduce string allocations, which were needed to convert to UTF8 and for splitting the strings in wrapped rendering. Instead I have solved both problems by almost always using sized strings and by moving the encoding specific string operations deeper into the call chain.

Also the way how layouting with the position buffer works is changed. The arrays are extracted from the font struct into an own position array, the struct contains a dummy element for ABI stability. The new array-struct is passed as an explicit parameter, which can be left `NULL`, to avoid allocation in `TTF_Size_Internal`.

## New functions
Each function related to rendering text has added an additional parameter `size_t text_size` after the `text` parameter.
- `TTF_Size*_SZ`
- `TTF_Measure*_SZ`
- `TTF_Render*_Solid_SZ`
- `TTF_Render*_Shaded_SZ`
- `TTF_Render*_Blended_SZ`
- `TTF_Render*_Solid_Wrapped_SZ`
- `TTF_Render*_Shaded_Wrapped_SZ`
- `TTF_Render*_Blended_Wrapped_SZ`

`*` represents all of `TEXT`, `UTF8`, `UNICODE`

## For the documentation of the new functions
For UTF8 and TEXT `text_size` denotes the number of bytes, for UNICODE it denotes the number of words (number of bytes / 2)

`NULL` can be passed as a paramter, as long as the size is also `0`.
The range `[text, text+text_size)` should be a valid string and thus a valid memory range.

## Showfont
Added new command line parameter `[-wrap width]` which forces to use the `*_Wrapped` functions with `width` as the `wrapLength` parameter.

## Problem
One problem, that might need to be discussed is the combinatoric explosion of rendering functions for the different formats.