### PR TITLE
Add CMake's target_include_directories also for build-tree

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,7 +83,11 @@ if (TARGET Freetype::Freetype)
 else()
   target_link_libraries(SDL2_ttf PkgConfig::freetype2)
 endif()
-target_include_directories(SDL2_ttf PUBLIC $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/SDL2>)
+
+target_include_directories(SDL2_ttf
+  PUBLIC $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/SDL2>
+  PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+)
 
 install(
   TARGETS SDL2_ttf


### PR DESCRIPTION
I changed CMakelists.txt target_include_directories to support a build-tree as it supports an install-tree in a case of add_subdirectory usage. It behaves like SDL_image in this case.

Basicaly what was already suggested here: https://github.com/libsdl-org/SDL_ttf/issues/143#issue-986901664