### PR TITLE
Added option to disable the installer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,6 +93,9 @@ target_include_directories(SDL2_ttf
   PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
 )
 
+option(SDL2_TTF_DISABLE_INSTALL "Disable installing SDL2_ttf" OFF)
+if (NOT SDL2_TTF_DISABLE_INSTALL)
+
 install(
   TARGETS SDL2_ttf
   EXPORT SDL2_ttfTargets
@@ -153,5 +156,7 @@ if (PKG_CONFIG_FOUND)
       DESTINATION "lib${LIB_SUFFIX}/pkgconfig")
   endif ()
 endif ()
+
+endif (NOT SDL2_TTF_DISABLE_INSTALL)
 
 endif()


### PR DESCRIPTION
Disabling installation is useful for projects which include SDL_ttf's source code directly through CMake, to avoid mixing SDL_ttf's installation targets with those of the project.

I made a [similar PR](https://github.com/libsdl-org/SDL/pull/5542) to SDL. Since I'm not sure how I should format my changes, I did the same as I did for SDL; I'm open to change it if wanted.