### PR TITLE
Sync up Create_Surface_LCD with other surface creation

### DIFF
--- a/SDL_ttf.c
+++ b/SDL_ttf.c
@@ -1615,7 +1615,7 @@ static SDL_Surface* Create_Surface_LCD(int width, int height, SDL_Color fg, SDL_
         }
 
         /* address is aligned */
-        pixels = (void *)(((size_t)ptr + sizeof(void *) + alignment) & ~alignment);
+        pixels = (void *)(((uintptr_t)ptr + sizeof(void *) + alignment) & ~alignment);
         ((void **)pixels)[-1] = ptr;
 
         textbuf = SDL_CreateRGBSurfaceWithFormatFrom(pixels, width, height, 0, pitch, SDL_PIXELFORMAT_ARGB8888);

--- a/SDL_ttf.c
+++ b/SDL_ttf.c
@@ -1600,7 +1600,7 @@ static SDL_Surface* Create_Surface_LCD(int width, int height, SDL_Color fg, SDL_
         Sint64 size;
         void *pixels, *ptr;
         /* Worse case at the end of line pulling 'alignment' extra blank pixels */
-        int pitch = (width + alignment) * 4;
+        Sint64 pitch = ((Sint64)width + (Sint64)alignment) * 4;
         pitch += alignment;
         pitch &= ~alignment;
         size = height * pitch + sizeof (void *) + alignment;


### PR DESCRIPTION
* Use 64-bit arithmetic in Create_Surface_LCD
    
    This catches up with commits 09a2294 "Fixed bug #187 - Arbitrary memory
    overwrite occurs when loading glyphs and rendering text with a
    malformed TTF" and db1b41a "More integer overflow (see bug #187)"
    in code that was written before those fixes, but merged after them.
    
    Fixes: f26fa4c "Add functions to use FreeType ClearType-style LCD rendering (#138)"

* Use uintptr_t in Create_Surface_LCD
    
    This catches up with commit 6095925 "replace size_t casts on pointers
    with uintptr_t" in code that was written before that commit, but merged
    after it. This makes all the code paths that call
    SDL_CreateRGBSurfaceWithFormatFrom() consistent with each other.
    
    Fixes: f26fa4c "Add functions to use FreeType ClearType-style LCD rendering (#138)"

---

Compile-tested only.