### PR TITLE
[Fix] Problem with DEPRECATION in CMAKE

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -395,8 +395,3 @@ add_library(SDL2::ttf INTERFACE IMPORTED GLOBAL)
 set_target_properties(SDL2::ttf PROPERTIES
     INTERFACE_LINK_LIBRARIES "SDL2_ttf"
 )
-if(CMAKE_VERSION VERSION_GREATER_EQUAL "3.17")
-    set_target_properties(SDL2::ttf PROPERTIES
-        DEPRECATION "Use SDL2_ttf::SDL2_ttf or SDL2_ttf::SDL2_ttf-static instead"
-    )
-endif()


### PR DESCRIPTION
When you use CMake on linux this if can create bug and stop compilation of SDL2_TTF 