### PR TITLE
Add TTF_GetFontScalable to distinguish bitmap vs outline fonts

### DIFF
--- a/SDL_ttf.c
+++ b/SDL_ttf.c
@@ -4248,4 +4248,13 @@ int TTF_GetFontKerningSizeGlyphs32(TTF_Font *font, Uint32 previous_ch, Uint32 ch
     return (int)(delta.x >> 6);
 }
 
+SDL_bool TTF_GetFontScalable(const TTF_Font *font)
+{
+    TTF_CHECK_POINTER(font, SDL_FALSE);
+    if (FT_IS_SCALABLE(font->face)) {
+        return SDL_TRUE;
+    }
+    return SDL_FALSE;
+}
+
 /* vi: set ts=4 sw=4 expandtab: */

--- a/include/SDL3/SDL_ttf.h
+++ b/include/SDL3/SDL_ttf.h
@@ -2311,6 +2311,21 @@ extern DECLSPEC int SDLCALL TTF_SetFontDirection(TTF_Font *font, TTF_Direction d
  */
 extern DECLSPEC int SDLCALL TTF_SetFontScriptName(TTF_Font *font, const char *script);
 
+/**
+ * Query whether a font is scalable or not.
+ *
+ * Scalability lets us distinguish between outline and bitmap fonts.
+ *
+ * \param font the font to query
+ *
+ * \returns SDL_TRUE if the font is scalable, SDL_FALSE otherwise.
+ *
+ * \since This function is available since SDL_ttf 2.21.0.
+ *
+ * \sa TTF_SetFontSDF
+ */
+extern DECLSPEC SDL_bool TTF_GetFontScalable(const TTF_Font *font);
+
 /* Ends C function definitions when using C++ */
 #ifdef __cplusplus
 }


### PR DESCRIPTION
closes #169

This is the freetype function used for bitmap font detection in pygame's `freetype` submodule. I've been recently looking at how feasible it is to replace the old `pygame.freetype` submodule with just our SDL_ttf wrapper `pygame.font` and one of the snags I noticed is bitmap font detection.

I looked over here and saw the issue so thought I'd have a stab at a PR.

My first SDL_ttf PR so I've almost certainly missed a bunch of things everyone is supposed to do. So, sorry about that.