### PR TITLE
Fixed Visual Studio project files with incorrect paths

### DIFF
--- a/VisualC-WinRT/SDL_ttf-UWP.vcxproj
+++ b/VisualC-WinRT/SDL_ttf-UWP.vcxproj
@@ -13,7 +13,7 @@
       <Configuration>Debug</Configuration>
       <Platform>x64</Platform>
     </ProjectConfiguration>
-    <ProjectConfiguration Include="Relefase|ARM">
+    <ProjectConfiguration Include="Release|ARM">
       <Configuration>Release</Configuration>
       <Platform>ARM</Platform>
     </ProjectConfiguration>

--- a/VisualC-WinRT/SDL_ttf-UWP.vcxproj
+++ b/VisualC-WinRT/SDL_ttf-UWP.vcxproj
@@ -13,7 +13,7 @@
       <Configuration>Debug</Configuration>
       <Platform>x64</Platform>
     </ProjectConfiguration>
-    <ProjectConfiguration Include="Release|ARM">
+    <ProjectConfiguration Include="Relefase|ARM">
       <Configuration>Release</Configuration>
       <Platform>ARM</Platform>
     </ProjectConfiguration>
@@ -27,7 +27,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <ItemGroup>
-    <ClInclude Include="..\SDL_ttf.h" />
+    <ClInclude Include="..\include\SDL3\SDL_ttf.h" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\SDL\VisualC-WinRT\SDL-UWP.vcxproj">

--- a/VisualC-WinRT/SDL_ttf-UWP.vcxproj.filters
+++ b/VisualC-WinRT/SDL_ttf-UWP.vcxproj.filters
@@ -275,7 +275,7 @@
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
-    <ClInclude Include="..\SDL_ttf.h">
+    <ClInclude Include="..\include\SDL3\SDL_ttf.h">
       <Filter>Public Headers</Filter>
     </ClInclude>
   </ItemGroup>

--- a/VisualC/SDL_ttf.vcxproj
+++ b/VisualC/SDL_ttf.vcxproj
@@ -360,7 +360,7 @@
     </ResourceCompile>
   </ItemGroup>
   <ItemGroup>
-    <ClInclude Include="..\SDL_ttf.h" />
+    <ClInclude Include="..\include\SDL3\SDL_ttf.h" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/VisualC/SDL_ttf.vcxproj.filters
+++ b/VisualC/SDL_ttf.vcxproj.filters
@@ -286,7 +286,7 @@
     </ResourceCompile>
   </ItemGroup>
   <ItemGroup>
-    <ClInclude Include="..\SDL_ttf.h">
+    <ClInclude Include="..\include\SDL3\SDL_ttf.h">
       <Filter>Public Headers</Filter>
     </ClInclude>
   </ItemGroup>


### PR DESCRIPTION
#290

This simply fixes the `.vcxproject` and `.vcxproject.filters` to point to the correct file.

It was previously just pointing to `..\SDL_ttf.h`, I assume this was the case at one point in time but it has seeming changed. It now points to `..\include\SDL3\SDL_ttf.h`.