### PR TITLE
Use SDL3_ttf_0.0.0 for versioned symbols, not SDL3_mixer_0.0.0

### DIFF
--- a/SDL_ttf.sym
+++ b/SDL_ttf.sym
@@ -1,4 +1,4 @@
-SDL3_mixer_0.0.0 {
+SDL3_ttf_0.0.0 {
   global:
     TTF_ByteSwappedUNICODE;
     TTF_CloseFont;


### PR DESCRIPTION
I assume this was a copy/paste mistake.