### PR TITLE
Fixed bug in setting ${prefix} for sdl2_ttf-config.cmake

### DIFF
--- a/sdl2_ttf-config.cmake.in
+++ b/sdl2_ttf-config.cmake.in
@@ -15,6 +15,7 @@ set(SDL2TTF_VENDORED @SDL2TTF_VENDORED@)
 
 set(SDL2TTF_SDL2_REQUIRED_VERSION @SDL_VERSION@)
 
+get_filename_component(CMAKE_CURRENT_LIST_DIR ${CMAKE_CURRENT_LIST_DIR} REALPATH)
 get_filename_component(prefix "${CMAKE_CURRENT_LIST_DIR}/@cmake_prefix_relpath@" ABSOLUTE)
 set(exec_prefix "@exec_prefix@")
 set(bindir "@bindir@")


### PR DESCRIPTION
Fixed bug:
```
CMake Error in CMakeLists.txt:
  Imported target "SDL2_ttf::SDL2_ttf" includes non-existent path

    "//include/SDL2"

  in its INTERFACE_INCLUDE_DIRECTORIES.  Possible reasons include:

  * The path was deleted, renamed, or moved to another location.

  * An install or uninstall procedure did not complete successfully.

  * The installation package was faulty and references files it does not
  provide.
```
when using SDL2_ttf::SDL2_ttf in CMake.