### PR TITLE
Remove deprecated functions from SDL3_ttf

### DIFF
--- a/examples/testapp.c
+++ b/examples/testapp.c
@@ -795,8 +795,6 @@ int main(void)
        }
 
        TTF_SetFontDirection(font, directions[direction].value);
-       //    TTF_SetScript(HB_SCRIPT_ARABIC);
-       //        TTF_SetScript(HB_SCRIPT_HAN);
 
        {
           int tmp;

--- a/include/SDL3_ttf/SDL_ttf.h
+++ b/include/SDL3_ttf/SDL_ttf.h
@@ -70,20 +70,6 @@ extern "C" {
 #define TTF_PATCHLEVEL      SDL_TTF_PATCHLEVEL
 #define TTF_VERSION(X)      SDL_TTF_VERSION(X)
 
-#if SDL_TTF_MAJOR_VERSION < 3 && SDL_MAJOR_VERSION < 3
-/**
- *  This is the version number macro for the current SDL_ttf version.
- *
- *  In versions higher than 2.9.0, the minor version overflows into
- *  the thousands digit: for example, 2.23.0 is encoded as 4300.
- *  This macro will not be available in SDL 3.x or SDL_ttf 3.x.
- *
- *  \deprecated, use SDL_TTF_VERSION_ATLEAST or SDL_TTF_VERSION instead.
- */
-#define SDL_TTF_COMPILEDVERSION \
-    SDL_VERSIONNUM(SDL_TTF_MAJOR_VERSION, SDL_TTF_MINOR_VERSION, SDL_TTF_PATCHLEVEL)
-#endif /* SDL_TTF_MAJOR_VERSION < 3 && SDL_MAJOR_VERSION < 3 */
-
 /**
  *  This macro will evaluate to true if compiled with SDL_ttf at least X.Y.Z.
  */

--- a/include/SDL3_ttf/SDL_ttf.h
+++ b/include/SDL3_ttf/SDL_ttf.h
@@ -92,11 +92,6 @@ extern "C" {
      (SDL_TTF_MAJOR_VERSION > X || SDL_TTF_MINOR_VERSION >= Y) && \
      (SDL_TTF_MAJOR_VERSION > X || SDL_TTF_MINOR_VERSION > Y || SDL_TTF_PATCHLEVEL >= Z))
 
-/* Make sure this is defined (only available in newer SDL versions) */
-#ifndef SDL_DEPRECATED
-#define SDL_DEPRECATED
-#endif
-
 /**
  * Query the version of SDL_ttf that the program is linked against.
  *

--- a/include/SDL3_ttf/SDL_ttf.h
+++ b/include/SDL3_ttf/SDL_ttf.h
@@ -2202,30 +2202,6 @@ typedef enum
 } TTF_Direction;
 
 /**
- * Set a global direction to be used for text shaping.
- *
- * \deprecated This function expects an hb_direction_t value, from HarfBuzz,
- *             cast to an int, and affects all fonts globally. Please use
- *             TTF_SetFontDirection() instead, which uses an enum supplied by
- *             SDL_ttf itself and operates on a per-font basis.
- *
- *             This is a global setting; fonts will favor a value set with
- *             TTF_SetFontDirection(), but if they have not had one explicitly
- *             set, they will use the value specified here.
- *
- *             The default value is `HB_DIRECTION_LTR` (left-to-right text
- *             flow).
- *
- * \param direction an hb_direction_t value.
- * \returns 0, or -1 if SDL_ttf is not compiled with HarfBuzz support.
- *
- * \since This function is available since SDL_ttf 3.0.0.
- *
- * \sa TTF_SetFontDirection
- */
-extern SDL_DEPRECATED DECLSPEC int SDLCALL TTF_SetDirection(int direction); /* hb_direction_t */
-
-/**
  * Set a global script to be used for text shaping.
  *
  * \deprecated This function expects an hb_script_t value, from HarfBuzz, cast
@@ -2250,9 +2226,6 @@ extern SDL_DEPRECATED DECLSPEC int SDLCALL TTF_SetScript(int script); /* hb_scri
 
 /**
  * Set direction to be used for text shaping by a font.
- *
- * Any value supplied here will override the global direction set with the
- * deprecated TTF_SetDirection().
  *
  * Possible direction values are:
  *

--- a/include/SDL3_ttf/SDL_ttf.h
+++ b/include/SDL3_ttf/SDL_ttf.h
@@ -2103,27 +2103,6 @@ extern DECLSPEC void SDLCALL TTF_Quit(void);
 extern DECLSPEC int SDLCALL TTF_WasInit(void);
 
 /**
- * Query the kerning size of two glyphs indices.
- *
- * \deprecated This function accidentally requires FreeType font indexes,
- *             not codepoints, which we don't expose through this API, so
- *             it could give wildly incorrect results, especially with
- *             non-ASCII values. Going forward, please use
- *             TTF_GetFontKerningSizeGlyphs() instead, which does what you
- *             probably expected this function to do.
- *
- * \param font the font to query.
- * \param prev_index the font index, NOT codepoint, of the previous character.
- * \param index the font index, NOT codepoint, of the current character.
- * \returns The kerning size between the two specified characters, in pixels, or -1 on error.
- *
- * \since This function is available since SDL_ttf 3.0.0.
- *
- * \sa TTF_GetFontKerningSizeGlyphs
- */
-extern SDL_DEPRECATED DECLSPEC int TTF_GetFontKerningSize(TTF_Font *font, int prev_index, int index);
-
-/**
  * Query the kerning size of two 16-bit glyphs.
  *
  * Note that this version of the function takes 16-bit character

--- a/include/SDL3_ttf/SDL_ttf.h
+++ b/include/SDL3_ttf/SDL_ttf.h
@@ -2202,29 +2202,6 @@ typedef enum
 } TTF_Direction;
 
 /**
- * Set a global script to be used for text shaping.
- *
- * \deprecated This function expects an hb_script_t value, from HarfBuzz, cast
- *             to an int, and affects all fonts globally. Please use
- *             TTF_SetFontScriptName() instead, which accepts a string that is
- *             converted to an equivalent int internally, and operates on a
- *             per-font basis.
- *
- *             This is a global setting; fonts will favor a value set with
- *             TTF_SetFontScriptName(), but if they have not had one
- *             explicitly set, they will use the value specified here.
- *
- *             The default value is `HB_SCRIPT_UNKNOWN`.
- *
- * \returns 0, or -1 if SDL_ttf is not compiled with HarfBuzz support.
- *
- * \since This function is available since SDL_ttf 3.0.0.
- *
- * \sa TTF_SetFontScriptName
- */
-extern SDL_DEPRECATED DECLSPEC int SDLCALL TTF_SetScript(int script); /* hb_script_t */
-
-/**
  * Set direction to be used for text shaping by a font.
  *
  * Possible direction values are:
@@ -2246,9 +2223,6 @@ extern DECLSPEC int SDLCALL TTF_SetFontDirection(TTF_Font *font, TTF_Direction d
 
 /**
  * Set script to be used for text shaping by a font.
- *
- * Any value supplied here will override the global script set with the
- * deprecated TTF_SetScript().
  *
  * The supplied script value must be a null-terminated string of exactly four
  * characters.

--- a/src/SDL_ttf.c
+++ b/src/SDL_ttf.c
@@ -87,18 +87,6 @@ static hb_direction_t g_hb_direction = HB_DIRECTION_LTR;
 static hb_script_t    g_hb_script = HB_SCRIPT_UNKNOWN;
 #endif
 
-/* Harfbuzz */
-int TTF_SetDirection(int direction) /* hb_direction_t */
-{
-#if TTF_USE_HARFBUZZ
-    g_hb_direction = direction;
-    return 0;
-#else
-    (void) direction;
-    return -1;
-#endif
-}
-
 int TTF_SetScript(int script) /* hb_script_t */
 {
 #if TTF_USE_HARFBUZZ

--- a/src/SDL_ttf.c
+++ b/src/SDL_ttf.c
@@ -4200,17 +4200,6 @@ int TTF_WasInit(void)
     return TTF_initialized;
 }
 
-/* don't use this function. It's just here for binary compatibility. */
-int TTF_GetFontKerningSize(TTF_Font *font, int prev_index, int index)
-{
-    FT_Vector delta;
-
-    TTF_CHECK_POINTER(font, -1);
-
-    FT_Get_Kerning(font->face, (FT_UInt)prev_index, (FT_UInt)index, FT_KERNING_DEFAULT, &delta);
-    return (int)(delta.x >> 6);
-}
-
 int TTF_GetFontKerningSizeGlyphs(TTF_Font *font, Uint16 previous_ch, Uint16 ch)
 {
     return TTF_GetFontKerningSizeGlyphs32(font, previous_ch, ch);

--- a/src/SDL_ttf.c
+++ b/src/SDL_ttf.c
@@ -87,17 +87,6 @@ static hb_direction_t g_hb_direction = HB_DIRECTION_LTR;
 static hb_script_t    g_hb_script = HB_SCRIPT_UNKNOWN;
 #endif
 
-int TTF_SetScript(int script) /* hb_script_t */
-{
-#if TTF_USE_HARFBUZZ
-    g_hb_script = script;
-    return 0;
-#else
-    (void) script;
-    return -1;
-#endif
-}
-
 /* Round glyph to 16 bytes width and use SSE2 instructions */
 #if defined(__SSE2__)
 #  define HAVE_SSE2_INTRINSICS 1

--- a/src/SDL_ttf.sym
+++ b/src/SDL_ttf.sym
@@ -12,7 +12,6 @@ SDL3_ttf_0.0.0 {
     TTF_FontLineSkip;
     TTF_GetFontHinting;
     TTF_GetFontKerning;
-    TTF_GetFontKerningSize;
     TTF_GetFontKerningSizeGlyphs;
     TTF_GetFontKerningSizeGlyphs32;
     TTF_GetFontOutline;

--- a/src/SDL_ttf.sym
+++ b/src/SDL_ttf.sym
@@ -81,7 +81,6 @@ SDL3_ttf_0.0.0 {
     TTF_SetFontSizeDPI;
     TTF_SetFontStyle;
     TTF_SetFontWrappedAlign;
-    TTF_SetScript;
     TTF_SizeText;
     TTF_SizeUNICODE;
     TTF_SizeUTF8;

--- a/src/SDL_ttf.sym
+++ b/src/SDL_ttf.sym
@@ -71,7 +71,6 @@ SDL3_ttf_0.0.0 {
     TTF_RenderUTF8_Shaded_Wrapped;
     TTF_RenderUTF8_Solid;
     TTF_RenderUTF8_Solid_Wrapped;
-    TTF_SetDirection;
     TTF_SetFontDirection;
     TTF_SetFontHinting;
     TTF_SetFontKerning;


### PR DESCRIPTION
It's now or ~never~ in 10 years.