### PR TITLE
Add TTF_GetScript to retreive the script to which unicode character belongs

### DIFF
--- a/SDL_ttf.h
+++ b/SDL_ttf.h
@@ -2311,6 +2311,24 @@ extern DECLSPEC int SDLCALL TTF_SetFontDirection(TTF_Font *font, TTF_Direction d
  */
 extern DECLSPEC int SDLCALL TTF_SetFontScriptName(TTF_Font *font, const char *script);
 
+/**
+ * Query the script to which unicode character belongs.
+ *
+ * The supplied script pointer should be able to hold four characters and
+ * the null-terminator.
+ *
+ * If SDL_ttf was not built with HarfBuzz support, this function returns -1.
+ *
+ * \param ch the character to check.
+ * \param script on return, filled in with the the script as a null-terminated
+ *               string of exactly 4 characters
+ * \param script_size size of the script buffer, must be at least 5 (see above.)
+ * \returns 0 on success, or -1 on error.
+ *
+ * \since This function is available since SDL_ttf 2.23.0.
+ */
+extern DECLSPEC int SDLCALL TTF_GetScriptName(Uint32 ch, char *script, size_t script_size);
+
 /* Ends C function definitions when using C++ */
 #ifdef __cplusplus
 }


### PR DESCRIPTION
At the moment **SDL_ttf** provides _TTF_SetFontScriptName_, a **Harfbuzz** related function that allows a script to be set (for a specific font) to be used for text shaping.

This is useful as long as the client knows the origin of its texts, allowing him to simply set the script relative to his language. If this isn't the case how would he know what to script to use? And what would happen if there are different characters in his text, each one requiring different scripts?

**Harfbuzz** already provides a way to obtain the best script to be used by each character. This PR exposes this functionally with _TTF_GetScript_, allowing the client to deal with this issue however he desires, without compromising the current library implementation