### PR TITLE
xcode: fix the list of files from the harfbuzz library.

### DIFF
--- a/Xcode/SDL_ttf.xcodeproj/project.pbxproj
+++ b/Xcode/SDL_ttf.xcodeproj/project.pbxproj
@@ -7,6 +7,52 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		618704E72B476A1500575B78 /* hb-outline.cc in Sources */ = {isa = PBXBuildFile; fileRef = 618704E62B476A1500575B78 /* hb-outline.cc */; };
+		618704E82B476A1500575B78 /* hb-outline.cc in Sources */ = {isa = PBXBuildFile; fileRef = 618704E62B476A1500575B78 /* hb-outline.cc */; };
+		618704EA2B476A5200575B78 /* hb-paint-extents.cc in Sources */ = {isa = PBXBuildFile; fileRef = 618704E92B476A5200575B78 /* hb-paint-extents.cc */; };
+		618704EB2B476A5200575B78 /* hb-paint-extents.cc in Sources */ = {isa = PBXBuildFile; fileRef = 618704E92B476A5200575B78 /* hb-paint-extents.cc */; };
+		618704ED2B476A9900575B78 /* hb-buffer-verify.cc in Sources */ = {isa = PBXBuildFile; fileRef = 618704EC2B476A9900575B78 /* hb-buffer-verify.cc */; };
+		618704EE2B476A9900575B78 /* hb-buffer-verify.cc in Sources */ = {isa = PBXBuildFile; fileRef = 618704EC2B476A9900575B78 /* hb-buffer-verify.cc */; };
+		618704F02B476B1900575B78 /* hb-ot-shaper-arabic.cc in Sources */ = {isa = PBXBuildFile; fileRef = 618704EF2B476B1900575B78 /* hb-ot-shaper-arabic.cc */; };
+		618704F12B476B1900575B78 /* hb-ot-shaper-arabic.cc in Sources */ = {isa = PBXBuildFile; fileRef = 618704EF2B476B1900575B78 /* hb-ot-shaper-arabic.cc */; };
+		618704F32B476B5800575B78 /* hb-ot-shaper-default.cc in Sources */ = {isa = PBXBuildFile; fileRef = 618704F22B476B5800575B78 /* hb-ot-shaper-default.cc */; };
+		618704F42B476B5800575B78 /* hb-ot-shaper-default.cc in Sources */ = {isa = PBXBuildFile; fileRef = 618704F22B476B5800575B78 /* hb-ot-shaper-default.cc */; };
+		618704FB2B476BAD00575B78 /* hb-ot-shaper-thai.cc in Sources */ = {isa = PBXBuildFile; fileRef = 618704F52B476BAD00575B78 /* hb-ot-shaper-thai.cc */; };
+		618704FC2B476BAD00575B78 /* hb-ot-shaper-thai.cc in Sources */ = {isa = PBXBuildFile; fileRef = 618704F52B476BAD00575B78 /* hb-ot-shaper-thai.cc */; };
+		618704FD2B476BAD00575B78 /* hb-ot-shaper-khmer.cc in Sources */ = {isa = PBXBuildFile; fileRef = 618704F62B476BAD00575B78 /* hb-ot-shaper-khmer.cc */; };
+		618704FE2B476BAD00575B78 /* hb-ot-shaper-khmer.cc in Sources */ = {isa = PBXBuildFile; fileRef = 618704F62B476BAD00575B78 /* hb-ot-shaper-khmer.cc */; };
+		618704FF2B476BAD00575B78 /* hb-ot-shaper-indic.cc in Sources */ = {isa = PBXBuildFile; fileRef = 618704F72B476BAD00575B78 /* hb-ot-shaper-indic.cc */; };
+		618705002B476BAD00575B78 /* hb-ot-shaper-indic.cc in Sources */ = {isa = PBXBuildFile; fileRef = 618704F72B476BAD00575B78 /* hb-ot-shaper-indic.cc */; };
+		618705012B476BAD00575B78 /* hb-ot-shaper-hebrew.cc in Sources */ = {isa = PBXBuildFile; fileRef = 618704F82B476BAD00575B78 /* hb-ot-shaper-hebrew.cc */; };
+		618705022B476BAD00575B78 /* hb-ot-shaper-hebrew.cc in Sources */ = {isa = PBXBuildFile; fileRef = 618704F82B476BAD00575B78 /* hb-ot-shaper-hebrew.cc */; };
+		618705032B476BAD00575B78 /* hb-ot-shaper-hangul.cc in Sources */ = {isa = PBXBuildFile; fileRef = 618704F92B476BAD00575B78 /* hb-ot-shaper-hangul.cc */; };
+		618705042B476BAD00575B78 /* hb-ot-shaper-hangul.cc in Sources */ = {isa = PBXBuildFile; fileRef = 618704F92B476BAD00575B78 /* hb-ot-shaper-hangul.cc */; };
+		618705052B476BAD00575B78 /* hb-ot-shaper-use.cc in Sources */ = {isa = PBXBuildFile; fileRef = 618704FA2B476BAD00575B78 /* hb-ot-shaper-use.cc */; };
+		618705062B476BAD00575B78 /* hb-ot-shaper-use.cc in Sources */ = {isa = PBXBuildFile; fileRef = 618704FA2B476BAD00575B78 /* hb-ot-shaper-use.cc */; };
+		6187050B2B476C1900575B78 /* hb-ot-shaper-myanmar.cc in Sources */ = {isa = PBXBuildFile; fileRef = 618705072B476C1800575B78 /* hb-ot-shaper-myanmar.cc */; };
+		6187050C2B476C1900575B78 /* hb-ot-shaper-myanmar.cc in Sources */ = {isa = PBXBuildFile; fileRef = 618705072B476C1800575B78 /* hb-ot-shaper-myanmar.cc */; };
+		6187050D2B476C1900575B78 /* hb-ot-shaper-syllabic.cc in Sources */ = {isa = PBXBuildFile; fileRef = 618705082B476C1800575B78 /* hb-ot-shaper-syllabic.cc */; };
+		6187050E2B476C1900575B78 /* hb-ot-shaper-syllabic.cc in Sources */ = {isa = PBXBuildFile; fileRef = 618705082B476C1800575B78 /* hb-ot-shaper-syllabic.cc */; };
+		6187050F2B476C1900575B78 /* hb-ot-shaper-indic-table.cc in Sources */ = {isa = PBXBuildFile; fileRef = 618705092B476C1900575B78 /* hb-ot-shaper-indic-table.cc */; };
+		618705102B476C1900575B78 /* hb-ot-shaper-indic-table.cc in Sources */ = {isa = PBXBuildFile; fileRef = 618705092B476C1900575B78 /* hb-ot-shaper-indic-table.cc */; };
+		618705112B476C1900575B78 /* hb-ot-shaper-vowel-constraints.cc in Sources */ = {isa = PBXBuildFile; fileRef = 6187050A2B476C1900575B78 /* hb-ot-shaper-vowel-constraints.cc */; };
+		618705122B476C1900575B78 /* hb-ot-shaper-vowel-constraints.cc in Sources */ = {isa = PBXBuildFile; fileRef = 6187050A2B476C1900575B78 /* hb-ot-shaper-vowel-constraints.cc */; };
+		618705162B476C8900575B78 /* hb-draw.cc in Sources */ = {isa = PBXBuildFile; fileRef = 618705132B476C8800575B78 /* hb-draw.cc */; };
+		618705172B476C8900575B78 /* hb-draw.cc in Sources */ = {isa = PBXBuildFile; fileRef = 618705132B476C8800575B78 /* hb-draw.cc */; };
+		618705182B476C8900575B78 /* hb-coretext.cc in Sources */ = {isa = PBXBuildFile; fileRef = 618705142B476C8900575B78 /* hb-coretext.cc */; };
+		618705192B476C8900575B78 /* hb-coretext.cc in Sources */ = {isa = PBXBuildFile; fileRef = 618705142B476C8900575B78 /* hb-coretext.cc */; };
+		6187051A2B476C8900575B78 /* hb-directwrite.cc in Sources */ = {isa = PBXBuildFile; fileRef = 618705152B476C8900575B78 /* hb-directwrite.cc */; };
+		6187051B2B476C8900575B78 /* hb-directwrite.cc in Sources */ = {isa = PBXBuildFile; fileRef = 618705152B476C8900575B78 /* hb-directwrite.cc */; };
+		6187051F2B476CF000575B78 /* hb-ot-meta.cc in Sources */ = {isa = PBXBuildFile; fileRef = 6187051C2B476CF000575B78 /* hb-ot-meta.cc */; };
+		618705202B476CF000575B78 /* hb-ot-meta.cc in Sources */ = {isa = PBXBuildFile; fileRef = 6187051C2B476CF000575B78 /* hb-ot-meta.cc */; };
+		618705212B476CF000575B78 /* hb-ot-name.cc in Sources */ = {isa = PBXBuildFile; fileRef = 6187051D2B476CF000575B78 /* hb-ot-name.cc */; };
+		618705222B476CF000575B78 /* hb-ot-name.cc in Sources */ = {isa = PBXBuildFile; fileRef = 6187051D2B476CF000575B78 /* hb-ot-name.cc */; };
+		618705232B476CF000575B78 /* hb-ot-color.cc in Sources */ = {isa = PBXBuildFile; fileRef = 6187051E2B476CF000575B78 /* hb-ot-color.cc */; };
+		618705242B476CF000575B78 /* hb-ot-color.cc in Sources */ = {isa = PBXBuildFile; fileRef = 6187051E2B476CF000575B78 /* hb-ot-color.cc */; };
+		618705272B476D2A00575B78 /* hb-paint.cc in Sources */ = {isa = PBXBuildFile; fileRef = 618705252B476D2A00575B78 /* hb-paint.cc */; };
+		618705282B476D2A00575B78 /* hb-paint.cc in Sources */ = {isa = PBXBuildFile; fileRef = 618705252B476D2A00575B78 /* hb-paint.cc */; };
+		618705292B476D2A00575B78 /* hb-cairo.cc in Sources */ = {isa = PBXBuildFile; fileRef = 618705262B476D2A00575B78 /* hb-cairo.cc */; };
+		6187052A2B476D2A00575B78 /* hb-cairo.cc in Sources */ = {isa = PBXBuildFile; fileRef = 618705262B476D2A00575B78 /* hb-cairo.cc */; };
 		7FC2F5DC285AC0D600836845 /* CMake in Resources */ = {isa = PBXBuildFile; fileRef = 7FC2F5DB285AC0D600836845 /* CMake */; };
 		BE48FD5F07AFA17000BB41DA /* SDL_ttf.h in Headers */ = {isa = PBXBuildFile; fileRef = 1014BAEA010A4B677F000001 /* SDL_ttf.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BE48FD6207AFA17000BB41DA /* SDL_ttf.c in Sources */ = {isa = PBXBuildFile; fileRef = F567D67A01CD962A01F3E8B9 /* SDL_ttf.c */; };
@@ -14,8 +60,6 @@
 		BE48FD8407AFA29000BB41DA /* SDL2.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BE48FD8307AFA29000BB41DA /* SDL2.framework */; };
 		F307EE29282738F8003915D7 /* svg.c in Sources */ = {isa = PBXBuildFile; fileRef = F307EE28282738F8003915D7 /* svg.c */; };
 		F307EE2A282738F8003915D7 /* svg.c in Sources */ = {isa = PBXBuildFile; fileRef = F307EE28282738F8003915D7 /* svg.c */; };
-		F307EE2C282807EB003915D7 /* hb-ms-feature-ranges.cc in Sources */ = {isa = PBXBuildFile; fileRef = F307EE2B282807EB003915D7 /* hb-ms-feature-ranges.cc */; };
-		F307EE2D282807EB003915D7 /* hb-ms-feature-ranges.cc in Sources */ = {isa = PBXBuildFile; fileRef = F307EE2B282807EB003915D7 /* hb-ms-feature-ranges.cc */; };
 		F364A5B82620E1A200325ECE /* FTL.TXT in Resources */ = {isa = PBXBuildFile; fileRef = F364A5B72620E1A200325ECE /* FTL.TXT */; };
 		F364A5C42620E22400325ECE /* ReadMe.txt in Resources */ = {isa = PBXBuildFile; fileRef = F364A5C32620E22400325ECE /* ReadMe.txt */; };
 		F3696FE4278F7107003A7F94 /* sdf.c in Sources */ = {isa = PBXBuildFile; fileRef = F3696FE3278F7107003A7F94 /* sdf.c */; };
@@ -100,24 +144,16 @@
 		F384BCE2261EC2CF0028A248 /* winfnt.c in Sources */ = {isa = PBXBuildFile; fileRef = F384BCDE261EC2CF0028A248 /* winfnt.c */; };
 		F384BCF2261EC5130028A248 /* ftcache.c in Sources */ = {isa = PBXBuildFile; fileRef = F384BCF1261EC5130028A248 /* ftcache.c */; };
 		F384BCF5261EC5130028A248 /* ftcache.c in Sources */ = {isa = PBXBuildFile; fileRef = F384BCF1261EC5130028A248 /* ftcache.c */; };
-		F384BD2F261EC7650028A248 /* hb-ot-shape-complex-default.cc in Sources */ = {isa = PBXBuildFile; fileRef = F384BD05261EC7640028A248 /* hb-ot-shape-complex-default.cc */; };
-		F384BD32261EC7650028A248 /* hb-ot-shape-complex-default.cc in Sources */ = {isa = PBXBuildFile; fileRef = F384BD05261EC7640028A248 /* hb-ot-shape-complex-default.cc */; };
 		F384BD35261EC7650028A248 /* hb-set.cc in Sources */ = {isa = PBXBuildFile; fileRef = F384BD06261EC7640028A248 /* hb-set.cc */; };
 		F384BD38261EC7650028A248 /* hb-set.cc in Sources */ = {isa = PBXBuildFile; fileRef = F384BD06261EC7640028A248 /* hb-set.cc */; };
 		F384BD3B261EC7650028A248 /* hb-shape.cc in Sources */ = {isa = PBXBuildFile; fileRef = F384BD07261EC7640028A248 /* hb-shape.cc */; };
 		F384BD3E261EC7650028A248 /* hb-shape.cc in Sources */ = {isa = PBXBuildFile; fileRef = F384BD07261EC7640028A248 /* hb-shape.cc */; };
 		F384BD41261EC7650028A248 /* hb-static.cc in Sources */ = {isa = PBXBuildFile; fileRef = F384BD08261EC7640028A248 /* hb-static.cc */; };
 		F384BD44261EC7650028A248 /* hb-static.cc in Sources */ = {isa = PBXBuildFile; fileRef = F384BD08261EC7640028A248 /* hb-static.cc */; };
-		F384BD47261EC7650028A248 /* hb-ot-shape-complex-hebrew.cc in Sources */ = {isa = PBXBuildFile; fileRef = F384BD09261EC7640028A248 /* hb-ot-shape-complex-hebrew.cc */; };
-		F384BD4A261EC7650028A248 /* hb-ot-shape-complex-hebrew.cc in Sources */ = {isa = PBXBuildFile; fileRef = F384BD09261EC7640028A248 /* hb-ot-shape-complex-hebrew.cc */; };
 		F384BD4D261EC7650028A248 /* hb-ucd.cc in Sources */ = {isa = PBXBuildFile; fileRef = F384BD0A261EC7640028A248 /* hb-ucd.cc */; };
 		F384BD50261EC7650028A248 /* hb-ucd.cc in Sources */ = {isa = PBXBuildFile; fileRef = F384BD0A261EC7640028A248 /* hb-ucd.cc */; };
-		F384BD53261EC7650028A248 /* hb-ot-shape-complex-indic-table.cc in Sources */ = {isa = PBXBuildFile; fileRef = F384BD0B261EC7640028A248 /* hb-ot-shape-complex-indic-table.cc */; };
-		F384BD56261EC7650028A248 /* hb-ot-shape-complex-indic-table.cc in Sources */ = {isa = PBXBuildFile; fileRef = F384BD0B261EC7640028A248 /* hb-ot-shape-complex-indic-table.cc */; };
 		F384BD59261EC7650028A248 /* hb-ot-map.cc in Sources */ = {isa = PBXBuildFile; fileRef = F384BD0C261EC7640028A248 /* hb-ot-map.cc */; };
 		F384BD5C261EC7650028A248 /* hb-ot-map.cc in Sources */ = {isa = PBXBuildFile; fileRef = F384BD0C261EC7640028A248 /* hb-ot-map.cc */; };
-		F384BD5F261EC7650028A248 /* hb-ot-shape-complex-hangul.cc in Sources */ = {isa = PBXBuildFile; fileRef = F384BD0D261EC7640028A248 /* hb-ot-shape-complex-hangul.cc */; };
-		F384BD62261EC7650028A248 /* hb-ot-shape-complex-hangul.cc in Sources */ = {isa = PBXBuildFile; fileRef = F384BD0D261EC7640028A248 /* hb-ot-shape-complex-hangul.cc */; };
 		F384BD65261EC7650028A248 /* hb-ot-font.cc in Sources */ = {isa = PBXBuildFile; fileRef = F384BD0E261EC7640028A248 /* hb-ot-font.cc */; };
 		F384BD68261EC7650028A248 /* hb-ot-font.cc in Sources */ = {isa = PBXBuildFile; fileRef = F384BD0E261EC7640028A248 /* hb-ot-font.cc */; };
 		F384BD6B261EC7650028A248 /* hb-shape-plan.cc in Sources */ = {isa = PBXBuildFile; fileRef = F384BD0F261EC7640028A248 /* hb-shape-plan.cc */; };
@@ -130,22 +166,12 @@
 		F384BD80261EC7650028A248 /* hb-ot-metrics.cc in Sources */ = {isa = PBXBuildFile; fileRef = F384BD12261EC7640028A248 /* hb-ot-metrics.cc */; };
 		F384BD83261EC7650028A248 /* hb-shaper.cc in Sources */ = {isa = PBXBuildFile; fileRef = F384BD13261EC7650028A248 /* hb-shaper.cc */; };
 		F384BD86261EC7650028A248 /* hb-shaper.cc in Sources */ = {isa = PBXBuildFile; fileRef = F384BD13261EC7650028A248 /* hb-shaper.cc */; };
-		F384BD89261EC7650028A248 /* hb-ot-shape-complex-arabic.cc in Sources */ = {isa = PBXBuildFile; fileRef = F384BD14261EC7650028A248 /* hb-ot-shape-complex-arabic.cc */; };
-		F384BD8C261EC7650028A248 /* hb-ot-shape-complex-arabic.cc in Sources */ = {isa = PBXBuildFile; fileRef = F384BD14261EC7650028A248 /* hb-ot-shape-complex-arabic.cc */; };
-		F384BD8F261EC7650028A248 /* hb-ot-shape-complex-vowel-constraints.cc in Sources */ = {isa = PBXBuildFile; fileRef = F384BD15261EC7650028A248 /* hb-ot-shape-complex-vowel-constraints.cc */; };
-		F384BD92261EC7650028A248 /* hb-ot-shape-complex-vowel-constraints.cc in Sources */ = {isa = PBXBuildFile; fileRef = F384BD15261EC7650028A248 /* hb-ot-shape-complex-vowel-constraints.cc */; };
 		F384BD95261EC7650028A248 /* hb-ot-layout.cc in Sources */ = {isa = PBXBuildFile; fileRef = F384BD16261EC7650028A248 /* hb-ot-layout.cc */; };
 		F384BD98261EC7650028A248 /* hb-ot-layout.cc in Sources */ = {isa = PBXBuildFile; fileRef = F384BD16261EC7650028A248 /* hb-ot-layout.cc */; };
-		F384BD9B261EC7650028A248 /* hb-ot-shape-complex-thai.cc in Sources */ = {isa = PBXBuildFile; fileRef = F384BD17261EC7650028A248 /* hb-ot-shape-complex-thai.cc */; };
-		F384BD9E261EC7650028A248 /* hb-ot-shape-complex-thai.cc in Sources */ = {isa = PBXBuildFile; fileRef = F384BD17261EC7650028A248 /* hb-ot-shape-complex-thai.cc */; };
-		F384BDA1261EC7650028A248 /* hb-ot-shape-complex-indic.cc in Sources */ = {isa = PBXBuildFile; fileRef = F384BD18261EC7650028A248 /* hb-ot-shape-complex-indic.cc */; };
-		F384BDA4261EC7650028A248 /* hb-ot-shape-complex-indic.cc in Sources */ = {isa = PBXBuildFile; fileRef = F384BD18261EC7650028A248 /* hb-ot-shape-complex-indic.cc */; };
 		F384BDA7261EC7650028A248 /* hb-buffer-serialize.cc in Sources */ = {isa = PBXBuildFile; fileRef = F384BD19261EC7650028A248 /* hb-buffer-serialize.cc */; };
 		F384BDAA261EC7650028A248 /* hb-buffer-serialize.cc in Sources */ = {isa = PBXBuildFile; fileRef = F384BD19261EC7650028A248 /* hb-buffer-serialize.cc */; };
 		F384BDAD261EC7650028A248 /* hb-font.cc in Sources */ = {isa = PBXBuildFile; fileRef = F384BD1A261EC7650028A248 /* hb-font.cc */; };
 		F384BDB0261EC7650028A248 /* hb-font.cc in Sources */ = {isa = PBXBuildFile; fileRef = F384BD1A261EC7650028A248 /* hb-font.cc */; };
-		F384BDB3261EC7650028A248 /* hb-ot-shape-complex-use.cc in Sources */ = {isa = PBXBuildFile; fileRef = F384BD1B261EC7650028A248 /* hb-ot-shape-complex-use.cc */; };
-		F384BDB6261EC7650028A248 /* hb-ot-shape-complex-use.cc in Sources */ = {isa = PBXBuildFile; fileRef = F384BD1B261EC7650028A248 /* hb-ot-shape-complex-use.cc */; };
 		F384BDB9261EC7650028A248 /* hb-unicode.cc in Sources */ = {isa = PBXBuildFile; fileRef = F384BD1C261EC7650028A248 /* hb-unicode.cc */; };
 		F384BDBC261EC7650028A248 /* hb-unicode.cc in Sources */ = {isa = PBXBuildFile; fileRef = F384BD1C261EC7650028A248 /* hb-unicode.cc */; };
 		F384BDBF261EC7650028A248 /* hb-buffer.cc in Sources */ = {isa = PBXBuildFile; fileRef = F384BD1D261EC7650028A248 /* hb-buffer.cc */; };
@@ -154,10 +180,6 @@
 		F384BDC8261EC7650028A248 /* hb-ot-cff2-table.cc in Sources */ = {isa = PBXBuildFile; fileRef = F384BD1E261EC7650028A248 /* hb-ot-cff2-table.cc */; };
 		F384BDCB261EC7650028A248 /* hb-ot-face.cc in Sources */ = {isa = PBXBuildFile; fileRef = F384BD1F261EC7650028A248 /* hb-ot-face.cc */; };
 		F384BDCE261EC7650028A248 /* hb-ot-face.cc in Sources */ = {isa = PBXBuildFile; fileRef = F384BD1F261EC7650028A248 /* hb-ot-face.cc */; };
-		F384BDD1261EC7650028A248 /* hb-ot-shape-complex-khmer.cc in Sources */ = {isa = PBXBuildFile; fileRef = F384BD20261EC7650028A248 /* hb-ot-shape-complex-khmer.cc */; };
-		F384BDD4261EC7650028A248 /* hb-ot-shape-complex-khmer.cc in Sources */ = {isa = PBXBuildFile; fileRef = F384BD20261EC7650028A248 /* hb-ot-shape-complex-khmer.cc */; };
-		F384BDD7261EC7650028A248 /* hb-ot-shape-complex-myanmar.cc in Sources */ = {isa = PBXBuildFile; fileRef = F384BD21261EC7650028A248 /* hb-ot-shape-complex-myanmar.cc */; };
-		F384BDDA261EC7650028A248 /* hb-ot-shape-complex-myanmar.cc in Sources */ = {isa = PBXBuildFile; fileRef = F384BD21261EC7650028A248 /* hb-ot-shape-complex-myanmar.cc */; };
 		F384BDDD261EC7650028A248 /* hb-aat-layout.cc in Sources */ = {isa = PBXBuildFile; fileRef = F384BD22261EC7650028A248 /* hb-aat-layout.cc */; };
 		F384BDE0261EC7650028A248 /* hb-aat-layout.cc in Sources */ = {isa = PBXBuildFile; fileRef = F384BD22261EC7650028A248 /* hb-aat-layout.cc */; };
 		F384BDE3261EC7650028A248 /* hb-common.cc in Sources */ = {isa = PBXBuildFile; fileRef = F384BD23261EC7650028A248 /* hb-common.cc */; };
@@ -182,8 +204,6 @@
 		F384BE1C261EC7650028A248 /* hb-ot-shape-fallback.cc in Sources */ = {isa = PBXBuildFile; fileRef = F384BD2C261EC7650028A248 /* hb-ot-shape-fallback.cc */; };
 		F384BE1F261EC7650028A248 /* hb-ot-shape.cc in Sources */ = {isa = PBXBuildFile; fileRef = F384BD2D261EC7650028A248 /* hb-ot-shape.cc */; };
 		F384BE22261EC7650028A248 /* hb-ot-shape.cc in Sources */ = {isa = PBXBuildFile; fileRef = F384BD2D261EC7650028A248 /* hb-ot-shape.cc */; };
-		F384BE25261EC7650028A248 /* hb-ot-shape-complex-syllabic.cc in Sources */ = {isa = PBXBuildFile; fileRef = F384BD2E261EC7650028A248 /* hb-ot-shape-complex-syllabic.cc */; };
-		F384BE28261EC7650028A248 /* hb-ot-shape-complex-syllabic.cc in Sources */ = {isa = PBXBuildFile; fileRef = F384BD2E261EC7650028A248 /* hb-ot-shape-complex-syllabic.cc */; };
 		F384BE48261EC9470028A248 /* hb-fallback-shape.cc in Sources */ = {isa = PBXBuildFile; fileRef = F384BE47261EC9470028A248 /* hb-fallback-shape.cc */; };
 		F384BE4B261EC9470028A248 /* hb-fallback-shape.cc in Sources */ = {isa = PBXBuildFile; fileRef = F384BE47261EC9470028A248 /* hb-fallback-shape.cc */; };
 		F384BE62261ECD9F0028A248 /* HarfBuzz-LICENSE.txt in Resources */ = {isa = PBXBuildFile; fileRef = F384BE60261ECD9F0028A248 /* HarfBuzz-LICENSE.txt */; };
@@ -215,6 +235,29 @@
 
 /* Begin PBXFileReference section */
 		1014BAEA010A4B677F000001 /* SDL_ttf.h */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.c.h; name = SDL_ttf.h; path = ../SDL_ttf.h; sourceTree = SOURCE_ROOT; };
+		618704E62B476A1500575B78 /* hb-outline.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-outline.cc"; path = "../external/harfbuzz/src/hb-outline.cc"; sourceTree = "<group>"; };
+		618704E92B476A5200575B78 /* hb-paint-extents.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-paint-extents.cc"; path = "../external/harfbuzz/src/hb-paint-extents.cc"; sourceTree = "<group>"; };
+		618704EC2B476A9900575B78 /* hb-buffer-verify.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-buffer-verify.cc"; path = "../external/harfbuzz/src/hb-buffer-verify.cc"; sourceTree = "<group>"; };
+		618704EF2B476B1900575B78 /* hb-ot-shaper-arabic.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-ot-shaper-arabic.cc"; path = "../external/harfbuzz/src/hb-ot-shaper-arabic.cc"; sourceTree = "<group>"; };
+		618704F22B476B5800575B78 /* hb-ot-shaper-default.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-ot-shaper-default.cc"; path = "../external/harfbuzz/src/hb-ot-shaper-default.cc"; sourceTree = "<group>"; };
+		618704F52B476BAD00575B78 /* hb-ot-shaper-thai.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-ot-shaper-thai.cc"; path = "../external/harfbuzz/src/hb-ot-shaper-thai.cc"; sourceTree = "<group>"; };
+		618704F62B476BAD00575B78 /* hb-ot-shaper-khmer.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-ot-shaper-khmer.cc"; path = "../external/harfbuzz/src/hb-ot-shaper-khmer.cc"; sourceTree = "<group>"; };
+		618704F72B476BAD00575B78 /* hb-ot-shaper-indic.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-ot-shaper-indic.cc"; path = "../external/harfbuzz/src/hb-ot-shaper-indic.cc"; sourceTree = "<group>"; };
+		618704F82B476BAD00575B78 /* hb-ot-shaper-hebrew.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-ot-shaper-hebrew.cc"; path = "../external/harfbuzz/src/hb-ot-shaper-hebrew.cc"; sourceTree = "<group>"; };
+		618704F92B476BAD00575B78 /* hb-ot-shaper-hangul.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-ot-shaper-hangul.cc"; path = "../external/harfbuzz/src/hb-ot-shaper-hangul.cc"; sourceTree = "<group>"; };
+		618704FA2B476BAD00575B78 /* hb-ot-shaper-use.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-ot-shaper-use.cc"; path = "../external/harfbuzz/src/hb-ot-shaper-use.cc"; sourceTree = "<group>"; };
+		618705072B476C1800575B78 /* hb-ot-shaper-myanmar.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-ot-shaper-myanmar.cc"; path = "../external/harfbuzz/src/hb-ot-shaper-myanmar.cc"; sourceTree = "<group>"; };
+		618705082B476C1800575B78 /* hb-ot-shaper-syllabic.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-ot-shaper-syllabic.cc"; path = "../external/harfbuzz/src/hb-ot-shaper-syllabic.cc"; sourceTree = "<group>"; };
+		618705092B476C1900575B78 /* hb-ot-shaper-indic-table.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-ot-shaper-indic-table.cc"; path = "../external/harfbuzz/src/hb-ot-shaper-indic-table.cc"; sourceTree = "<group>"; };
+		6187050A2B476C1900575B78 /* hb-ot-shaper-vowel-constraints.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-ot-shaper-vowel-constraints.cc"; path = "../external/harfbuzz/src/hb-ot-shaper-vowel-constraints.cc"; sourceTree = "<group>"; };
+		618705132B476C8800575B78 /* hb-draw.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-draw.cc"; path = "../external/harfbuzz/src/hb-draw.cc"; sourceTree = "<group>"; };
+		618705142B476C8900575B78 /* hb-coretext.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-coretext.cc"; path = "../external/harfbuzz/src/hb-coretext.cc"; sourceTree = "<group>"; };
+		618705152B476C8900575B78 /* hb-directwrite.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-directwrite.cc"; path = "../external/harfbuzz/src/hb-directwrite.cc"; sourceTree = "<group>"; };
+		6187051C2B476CF000575B78 /* hb-ot-meta.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-ot-meta.cc"; path = "../external/harfbuzz/src/hb-ot-meta.cc"; sourceTree = "<group>"; };
+		6187051D2B476CF000575B78 /* hb-ot-name.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-ot-name.cc"; path = "../external/harfbuzz/src/hb-ot-name.cc"; sourceTree = "<group>"; };
+		6187051E2B476CF000575B78 /* hb-ot-color.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-ot-color.cc"; path = "../external/harfbuzz/src/hb-ot-color.cc"; sourceTree = "<group>"; };
+		618705252B476D2A00575B78 /* hb-paint.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-paint.cc"; path = "../external/harfbuzz/src/hb-paint.cc"; sourceTree = "<group>"; };
+		618705262B476D2A00575B78 /* hb-cairo.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-cairo.cc"; path = "../external/harfbuzz/src/hb-cairo.cc"; sourceTree = "<group>"; };
 		7FC2F5DB285AC0D600836845 /* CMake */ = {isa = PBXFileReference; lastKnownFileType = folder; path = CMake; sourceTree = "<group>"; };
 		A75FDB0C23E37ED200529352 /* SDL2.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SDL2.framework; path = iOS/SDL2.framework; sourceTree = "<group>"; };
 		A75FDB1023E37EE400529352 /* SDL2.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SDL2.framework; path = tvOS/SDL2.framework; sourceTree = "<group>"; };
@@ -224,7 +267,6 @@
 		BE48FD7207AFA17000BB41DA /* Create DMG */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = "Create DMG"; sourceTree = BUILT_PRODUCTS_DIR; };
 		BE48FD8307AFA29000BB41DA /* SDL2.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = SDL2.framework; sourceTree = "<group>"; };
 		F307EE28282738F8003915D7 /* svg.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = svg.c; path = ../external/freetype/src/svg/svg.c; sourceTree = "<group>"; };
-		F307EE2B282807EB003915D7 /* hb-ms-feature-ranges.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-ms-feature-ranges.cc"; path = "../external/harfbuzz/src/hb-ms-feature-ranges.cc"; sourceTree = "<group>"; };
 		F364A5B72620E1A200325ECE /* FTL.TXT */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = FTL.TXT; path = ../../../external/freetype/docs/FTL.TXT; sourceTree = "<group>"; };
 		F364A5C32620E22400325ECE /* ReadMe.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = ReadMe.txt; sourceTree = "<group>"; };
 		F3696FE3278F7107003A7F94 /* sdf.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = sdf.c; path = ../external/freetype/src/sdf/sdf.c; sourceTree = "<group>"; };
@@ -268,35 +310,24 @@
 		F384BCD3261EC2BE0028A248 /* type42.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = type42.c; path = ../external/freetype/src/type42/type42.c; sourceTree = "<group>"; };
 		F384BCDE261EC2CF0028A248 /* winfnt.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = winfnt.c; path = ../external/freetype/src/winfonts/winfnt.c; sourceTree = "<group>"; };
 		F384BCF1261EC5130028A248 /* ftcache.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = ftcache.c; path = ../external/freetype/src/cache/ftcache.c; sourceTree = "<group>"; };
-		F384BD05261EC7640028A248 /* hb-ot-shape-complex-default.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-ot-shape-complex-default.cc"; path = "../external/harfbuzz/src/hb-ot-shape-complex-default.cc"; sourceTree = "<group>"; };
 		F384BD06261EC7640028A248 /* hb-set.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-set.cc"; path = "../external/harfbuzz/src/hb-set.cc"; sourceTree = "<group>"; };
 		F384BD07261EC7640028A248 /* hb-shape.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-shape.cc"; path = "../external/harfbuzz/src/hb-shape.cc"; sourceTree = "<group>"; };
 		F384BD08261EC7640028A248 /* hb-static.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-static.cc"; path = "../external/harfbuzz/src/hb-static.cc"; sourceTree = "<group>"; };
-		F384BD09261EC7640028A248 /* hb-ot-shape-complex-hebrew.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-ot-shape-complex-hebrew.cc"; path = "../external/harfbuzz/src/hb-ot-shape-complex-hebrew.cc"; sourceTree = "<group>"; };
 		F384BD0A261EC7640028A248 /* hb-ucd.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-ucd.cc"; path = "../external/harfbuzz/src/hb-ucd.cc"; sourceTree = "<group>"; };
-		F384BD0B261EC7640028A248 /* hb-ot-shape-complex-indic-table.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-ot-shape-complex-indic-table.cc"; path = "../external/harfbuzz/src/hb-ot-shape-complex-indic-table.cc"; sourceTree = "<group>"; };
 		F384BD0C261EC7640028A248 /* hb-ot-map.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-ot-map.cc"; path = "../external/harfbuzz/src/hb-ot-map.cc"; sourceTree = "<group>"; };
-		F384BD0D261EC7640028A248 /* hb-ot-shape-complex-hangul.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-ot-shape-complex-hangul.cc"; path = "../external/harfbuzz/src/hb-ot-shape-complex-hangul.cc"; sourceTree = "<group>"; };
 		F384BD0E261EC7640028A248 /* hb-ot-font.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-ot-font.cc"; path = "../external/harfbuzz/src/hb-ot-font.cc"; sourceTree = "<group>"; };
 		F384BD0F261EC7640028A248 /* hb-shape-plan.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-shape-plan.cc"; path = "../external/harfbuzz/src/hb-shape-plan.cc"; sourceTree = "<group>"; };
 		F384BD10261EC7640028A248 /* hb-ot-tag.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-ot-tag.cc"; path = "../external/harfbuzz/src/hb-ot-tag.cc"; sourceTree = "<group>"; };
 		F384BD11261EC7640028A248 /* hb-number.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-number.cc"; path = "../external/harfbuzz/src/hb-number.cc"; sourceTree = "<group>"; };
 		F384BD12261EC7640028A248 /* hb-ot-metrics.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-ot-metrics.cc"; path = "../external/harfbuzz/src/hb-ot-metrics.cc"; sourceTree = "<group>"; };
 		F384BD13261EC7650028A248 /* hb-shaper.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-shaper.cc"; path = "../external/harfbuzz/src/hb-shaper.cc"; sourceTree = "<group>"; };
-		F384BD14261EC7650028A248 /* hb-ot-shape-complex-arabic.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-ot-shape-complex-arabic.cc"; path = "../external/harfbuzz/src/hb-ot-shape-complex-arabic.cc"; sourceTree = "<group>"; };
-		F384BD15261EC7650028A248 /* hb-ot-shape-complex-vowel-constraints.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-ot-shape-complex-vowel-constraints.cc"; path = "../external/harfbuzz/src/hb-ot-shape-complex-vowel-constraints.cc"; sourceTree = "<group>"; };
 		F384BD16261EC7650028A248 /* hb-ot-layout.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-ot-layout.cc"; path = "../external/harfbuzz/src/hb-ot-layout.cc"; sourceTree = "<group>"; };
-		F384BD17261EC7650028A248 /* hb-ot-shape-complex-thai.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-ot-shape-complex-thai.cc"; path = "../external/harfbuzz/src/hb-ot-shape-complex-thai.cc"; sourceTree = "<group>"; };
-		F384BD18261EC7650028A248 /* hb-ot-shape-complex-indic.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-ot-shape-complex-indic.cc"; path = "../external/harfbuzz/src/hb-ot-shape-complex-indic.cc"; sourceTree = "<group>"; };
 		F384BD19261EC7650028A248 /* hb-buffer-serialize.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-buffer-serialize.cc"; path = "../external/harfbuzz/src/hb-buffer-serialize.cc"; sourceTree = "<group>"; };
 		F384BD1A261EC7650028A248 /* hb-font.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-font.cc"; path = "../external/harfbuzz/src/hb-font.cc"; sourceTree = "<group>"; };
-		F384BD1B261EC7650028A248 /* hb-ot-shape-complex-use.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-ot-shape-complex-use.cc"; path = "../external/harfbuzz/src/hb-ot-shape-complex-use.cc"; sourceTree = "<group>"; };
 		F384BD1C261EC7650028A248 /* hb-unicode.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-unicode.cc"; path = "../external/harfbuzz/src/hb-unicode.cc"; sourceTree = "<group>"; };
 		F384BD1D261EC7650028A248 /* hb-buffer.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-buffer.cc"; path = "../external/harfbuzz/src/hb-buffer.cc"; sourceTree = "<group>"; };
 		F384BD1E261EC7650028A248 /* hb-ot-cff2-table.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-ot-cff2-table.cc"; path = "../external/harfbuzz/src/hb-ot-cff2-table.cc"; sourceTree = "<group>"; };
 		F384BD1F261EC7650028A248 /* hb-ot-face.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-ot-face.cc"; path = "../external/harfbuzz/src/hb-ot-face.cc"; sourceTree = "<group>"; };
-		F384BD20261EC7650028A248 /* hb-ot-shape-complex-khmer.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-ot-shape-complex-khmer.cc"; path = "../external/harfbuzz/src/hb-ot-shape-complex-khmer.cc"; sourceTree = "<group>"; };
-		F384BD21261EC7650028A248 /* hb-ot-shape-complex-myanmar.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-ot-shape-complex-myanmar.cc"; path = "../external/harfbuzz/src/hb-ot-shape-complex-myanmar.cc"; sourceTree = "<group>"; };
 		F384BD22261EC7650028A248 /* hb-aat-layout.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-aat-layout.cc"; path = "../external/harfbuzz/src/hb-aat-layout.cc"; sourceTree = "<group>"; };
 		F384BD23261EC7650028A248 /* hb-common.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-common.cc"; path = "../external/harfbuzz/src/hb-common.cc"; sourceTree = "<group>"; };
 		F384BD24261EC7650028A248 /* hb-ot-cff1-table.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-ot-cff1-table.cc"; path = "../external/harfbuzz/src/hb-ot-cff1-table.cc"; sourceTree = "<group>"; };
@@ -309,7 +340,6 @@
 		F384BD2B261EC7650028A248 /* hb-ot-math.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-ot-math.cc"; path = "../external/harfbuzz/src/hb-ot-math.cc"; sourceTree = "<group>"; };
 		F384BD2C261EC7650028A248 /* hb-ot-shape-fallback.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-ot-shape-fallback.cc"; path = "../external/harfbuzz/src/hb-ot-shape-fallback.cc"; sourceTree = "<group>"; };
 		F384BD2D261EC7650028A248 /* hb-ot-shape.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-ot-shape.cc"; path = "../external/harfbuzz/src/hb-ot-shape.cc"; sourceTree = "<group>"; };
-		F384BD2E261EC7650028A248 /* hb-ot-shape-complex-syllabic.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-ot-shape-complex-syllabic.cc"; path = "../external/harfbuzz/src/hb-ot-shape-complex-syllabic.cc"; sourceTree = "<group>"; };
 		F384BE47261EC9470028A248 /* hb-fallback-shape.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-fallback-shape.cc"; path = "../external/harfbuzz/src/hb-fallback-shape.cc"; sourceTree = "<group>"; };
 		F384BE60261ECD9F0028A248 /* HarfBuzz-LICENSE.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = "HarfBuzz-LICENSE.txt"; sourceTree = "<group>"; };
 		F384BE61261ECD9F0028A248 /* FreeType-LICENSE.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = "FreeType-LICENSE.txt"; sourceTree = "<group>"; };
@@ -479,17 +509,39 @@
 		F384BD04261EC64F0028A248 /* HarfBuzz */ = {
 			isa = PBXGroup;
 			children = (
+				618705092B476C1900575B78 /* hb-ot-shaper-indic-table.cc */,
+				618705072B476C1800575B78 /* hb-ot-shaper-myanmar.cc */,
+				618705082B476C1800575B78 /* hb-ot-shaper-syllabic.cc */,
+				6187050A2B476C1900575B78 /* hb-ot-shaper-vowel-constraints.cc */,
+				618704F92B476BAD00575B78 /* hb-ot-shaper-hangul.cc */,
+				618705142B476C8900575B78 /* hb-coretext.cc */,
+				618705152B476C8900575B78 /* hb-directwrite.cc */,
+				618705132B476C8800575B78 /* hb-draw.cc */,
+				618704F82B476BAD00575B78 /* hb-ot-shaper-hebrew.cc */,
+				618704F72B476BAD00575B78 /* hb-ot-shaper-indic.cc */,
+				618704F62B476BAD00575B78 /* hb-ot-shaper-khmer.cc */,
+				618704F52B476BAD00575B78 /* hb-ot-shaper-thai.cc */,
+				618704FA2B476BAD00575B78 /* hb-ot-shaper-use.cc */,
+				6187051E2B476CF000575B78 /* hb-ot-color.cc */,
+				6187051C2B476CF000575B78 /* hb-ot-meta.cc */,
+				6187051D2B476CF000575B78 /* hb-ot-name.cc */,
+				618704F22B476B5800575B78 /* hb-ot-shaper-default.cc */,
+				618704EF2B476B1900575B78 /* hb-ot-shaper-arabic.cc */,
+				618704EC2B476A9900575B78 /* hb-buffer-verify.cc */,
+				618704E92B476A5200575B78 /* hb-paint-extents.cc */,
+				618704E62B476A1500575B78 /* hb-outline.cc */,
 				F384BD22261EC7650028A248 /* hb-aat-layout.cc */,
 				F384BD27261EC7650028A248 /* hb-aat-map.cc */,
 				F384BD26261EC7650028A248 /* hb-blob.cc */,
 				F384BD19261EC7650028A248 /* hb-buffer-serialize.cc */,
+				618705262B476D2A00575B78 /* hb-cairo.cc */,
+				618705252B476D2A00575B78 /* hb-paint.cc */,
 				F384BD1D261EC7650028A248 /* hb-buffer.cc */,
 				F384BD23261EC7650028A248 /* hb-common.cc */,
 				F384BD25261EC7650028A248 /* hb-face.cc */,
 				F384BE47261EC9470028A248 /* hb-fallback-shape.cc */,
 				F384BD1A261EC7650028A248 /* hb-font.cc */,
 				F384BD28261EC7650028A248 /* hb-ft.cc */,
-				F307EE2B282807EB003915D7 /* hb-ms-feature-ranges.cc */,
 				F384BD11261EC7640028A248 /* hb-number.cc */,
 				F384BD24261EC7650028A248 /* hb-ot-cff1-table.cc */,
 				F384BD1E261EC7650028A248 /* hb-ot-cff2-table.cc */,
@@ -499,18 +551,6 @@
 				F384BD0C261EC7640028A248 /* hb-ot-map.cc */,
 				F384BD2B261EC7650028A248 /* hb-ot-math.cc */,
 				F384BD12261EC7640028A248 /* hb-ot-metrics.cc */,
-				F384BD14261EC7650028A248 /* hb-ot-shape-complex-arabic.cc */,
-				F384BD05261EC7640028A248 /* hb-ot-shape-complex-default.cc */,
-				F384BD0D261EC7640028A248 /* hb-ot-shape-complex-hangul.cc */,
-				F384BD09261EC7640028A248 /* hb-ot-shape-complex-hebrew.cc */,
-				F384BD0B261EC7640028A248 /* hb-ot-shape-complex-indic-table.cc */,
-				F384BD18261EC7650028A248 /* hb-ot-shape-complex-indic.cc */,
-				F384BD20261EC7650028A248 /* hb-ot-shape-complex-khmer.cc */,
-				F384BD21261EC7650028A248 /* hb-ot-shape-complex-myanmar.cc */,
-				F384BD2E261EC7650028A248 /* hb-ot-shape-complex-syllabic.cc */,
-				F384BD17261EC7650028A248 /* hb-ot-shape-complex-thai.cc */,
-				F384BD1B261EC7650028A248 /* hb-ot-shape-complex-use.cc */,
-				F384BD15261EC7650028A248 /* hb-ot-shape-complex-vowel-constraints.cc */,
 				F384BD2C261EC7650028A248 /* hb-ot-shape-fallback.cc */,
 				F384BD29261EC7650028A248 /* hb-ot-shape-normalize.cc */,
 				F384BD2D261EC7650028A248 /* hb-ot-shape.cc */,
@@ -720,92 +760,102 @@
 			buildActionMask = 2147483647;
 			files = (
 				F384BB8B261EC0DE0028A248 /* ftbdf.c in Sources */,
-				F384BD8F261EC7650028A248 /* hb-ot-shape-complex-vowel-constraints.cc in Sources */,
 				F384BBBB261EC0DE0028A248 /* ftglyph.c in Sources */,
+				6187050F2B476C1900575B78 /* hb-ot-shaper-indic-table.cc in Sources */,
 				F384BC3A261EC1890028A248 /* type1cid.c in Sources */,
 				F384BC71261EC2050028A248 /* psaux.c in Sources */,
 				F384BD35261EC7650028A248 /* hb-set.cc in Sources */,
+				618704FB2B476BAD00575B78 /* hb-ot-shaper-thai.cc in Sources */,
+				618704F32B476B5800575B78 /* hb-ot-shaper-default.cc in Sources */,
+				618704E72B476A1500575B78 /* hb-outline.cc in Sources */,
+				618705182B476C8900575B78 /* hb-coretext.cc in Sources */,
 				F384BC9D261EC2680028A248 /* sfnt.c in Sources */,
 				F384BDE9261EC7650028A248 /* hb-ot-cff1-table.cc in Sources */,
-				F384BE25261EC7650028A248 /* hb-ot-shape-complex-syllabic.cc in Sources */,
-				F384BDD1261EC7650028A248 /* hb-ot-shape-complex-khmer.cc in Sources */,
 				F384BCBE261EC2980028A248 /* truetype.c in Sources */,
 				F384BD59261EC7650028A248 /* hb-ot-map.cc in Sources */,
+				6187051A2B476C8900575B78 /* hb-directwrite.cc in Sources */,
 				F384BBD9261EC0DE0028A248 /* ftcid.c in Sources */,
 				F384BDBF261EC7650028A248 /* hb-buffer.cc in Sources */,
+				618705052B476BAD00575B78 /* hb-ot-shaper-use.cc in Sources */,
 				F384BD83261EC7650028A248 /* hb-shaper.cc in Sources */,
 				F384BCD4261EC2BE0028A248 /* type42.c in Sources */,
+				618704ED2B476A9900575B78 /* hb-buffer-verify.cc in Sources */,
 				F384BDEF261EC7650028A248 /* hb-face.cc in Sources */,
+				6187050B2B476C1900575B78 /* hb-ot-shaper-myanmar.cc in Sources */,
 				F384BCDF261EC2CF0028A248 /* winfnt.c in Sources */,
 				F384BC2F261EC1710028A248 /* cff.c in Sources */,
+				618705292B476D2A00575B78 /* hb-cairo.cc in Sources */,
+				618705212B476CF000575B78 /* hb-ot-name.cc in Sources */,
+				618705232B476CF000575B78 /* hb-ot-color.cc in Sources */,
 				F384BDA7261EC7650028A248 /* hb-buffer-serialize.cc in Sources */,
 				F384BBC1261EC0DE0028A248 /* ftsynth.c in Sources */,
+				618705162B476C8900575B78 /* hb-draw.cc in Sources */,
 				F384BE07261EC7650028A248 /* hb-ot-shape-normalize.cc in Sources */,
 				F384BD41261EC7650028A248 /* hb-static.cc in Sources */,
 				F384BD77261EC7650028A248 /* hb-number.cc in Sources */,
 				F384BBCD261EC0DE0028A248 /* ftinit.c in Sources */,
 				F384BE1F261EC7650028A248 /* hb-ot-shape.cc in Sources */,
-				F384BDD7261EC7650028A248 /* hb-ot-shape-complex-myanmar.cc in Sources */,
 				F384BD6B261EC7650028A248 /* hb-shape-plan.cc in Sources */,
+				618705032B476BAD00575B78 /* hb-ot-shaper-hangul.cc in Sources */,
 				F384BBAF261EC0DE0028A248 /* ftbase.c in Sources */,
 				F384BC5B261EC1DF0028A248 /* pcf.c in Sources */,
 				F384BC50261EC1B90028A248 /* ftlzw.c in Sources */,
 				F384BBF1261EC0DE0028A248 /* ftsystem.c in Sources */,
+				618705012B476BAD00575B78 /* hb-ot-shaper-hebrew.cc in Sources */,
+				6187051F2B476CF000575B78 /* hb-ot-meta.cc in Sources */,
 				F384BBDF261EC0DE0028A248 /* ftpfr.c in Sources */,
-				F384BDB3261EC7650028A248 /* hb-ot-shape-complex-use.cc in Sources */,
 				F384BDC5261EC7650028A248 /* hb-ot-cff2-table.cc in Sources */,
 				F384BE13261EC7650028A248 /* hb-ot-math.cc in Sources */,
 				F384BBD3261EC0DE0028A248 /* ftmm.c in Sources */,
 				F384BD71261EC7650028A248 /* hb-ot-tag.cc in Sources */,
 				F384BC03261EC0DE0028A248 /* fttype1.c in Sources */,
 				F384BB9D261EC0DE0028A248 /* ftstroke.c in Sources */,
-				F384BD5F261EC7650028A248 /* hb-ot-shape-complex-hangul.cc in Sources */,
+				618705272B476D2A00575B78 /* hb-paint.cc in Sources */,
 				F384BC45261EC1A30028A248 /* ftgzip.c in Sources */,
 				F307EE29282738F8003915D7 /* svg.c in Sources */,
 				F384BB6C261EC0760028A248 /* autofit.c in Sources */,
-				F384BD53261EC7650028A248 /* hb-ot-shape-complex-indic-table.cc in Sources */,
 				F384BDFB261EC7650028A248 /* hb-aat-map.cc in Sources */,
 				F384BB91261EC0DE0028A248 /* ftgasp.c in Sources */,
 				F384BBF7261EC0DE0028A248 /* ftwinfnt.c in Sources */,
 				BE48FD6207AFA17000BB41DA /* SDL_ttf.c in Sources */,
-				F384BD89261EC7650028A248 /* hb-ot-shape-complex-arabic.cc in Sources */,
 				F384BDE3261EC7650028A248 /* hb-common.cc in Sources */,
 				F384BD7D261EC7650028A248 /* hb-ot-metrics.cc in Sources */,
 				F384BDDD261EC7650028A248 /* hb-aat-layout.cc in Sources */,
+				618704EA2B476A5200575B78 /* hb-paint-extents.cc in Sources */,
 				F384BDF5261EC7650028A248 /* hb-blob.cc in Sources */,
-				F384BD9B261EC7650028A248 /* hb-ot-shape-complex-thai.cc in Sources */,
 				F384BCC9261EC2AE0028A248 /* type1.c in Sources */,
 				F384BD3B261EC7650028A248 /* hb-shape.cc in Sources */,
 				F384BC92261EC2560028A248 /* raster.c in Sources */,
 				F384BDCB261EC7650028A248 /* hb-ot-face.cc in Sources */,
 				F384BB97261EC0DE0028A248 /* ftgxval.c in Sources */,
 				F384BDAD261EC7650028A248 /* hb-font.cc in Sources */,
+				618704F02B476B1900575B78 /* hb-ot-shaper-arabic.cc in Sources */,
 				F384BD4D261EC7650028A248 /* hb-ucd.cc in Sources */,
 				F384BBB5261EC0DE0028A248 /* ftpatent.c in Sources */,
+				618704FD2B476BAD00575B78 /* hb-ot-shaper-khmer.cc in Sources */,
+				6187050D2B476C1900575B78 /* hb-ot-shaper-syllabic.cc in Sources */,
 				F3696FE4278F7107003A7F94 /* sdf.c in Sources */,
 				F384BE01261EC7650028A248 /* hb-ft.cc in Sources */,
 				F384BE19261EC7650028A248 /* hb-ot-shape-fallback.cc in Sources */,
 				F384BD95261EC7650028A248 /* hb-ot-layout.cc in Sources */,
-				F307EE2C282807EB003915D7 /* hb-ms-feature-ranges.cc in Sources */,
 				F384BC0E261EC0F90028A248 /* bdf.c in Sources */,
 				F384BC87261EC23B0028A248 /* psmodule.c in Sources */,
 				F384BE0D261EC7650028A248 /* hb-ot-var.cc in Sources */,
 				F384BBE5261EC0DE0028A248 /* ftotval.c in Sources */,
-				F384BD2F261EC7650028A248 /* hb-ot-shape-complex-default.cc in Sources */,
 				F384BBEB261EC0DE0028A248 /* ftfstype.c in Sources */,
 				F384BC7C261EC2180028A248 /* pshinter.c in Sources */,
 				F384BD65261EC7650028A248 /* hb-ot-font.cc in Sources */,
 				F384BBC7261EC0DE0028A248 /* ftbitmap.c in Sources */,
+				618704FF2B476BAD00575B78 /* hb-ot-shaper-indic.cc in Sources */,
 				F384BCA8261EC2770028A248 /* smooth.c in Sources */,
-				F384BD47261EC7650028A248 /* hb-ot-shape-complex-hebrew.cc in Sources */,
 				F384BBA9261EC0DE0028A248 /* ftbbox.c in Sources */,
 				F384BE48261EC9470028A248 /* hb-fallback-shape.cc in Sources */,
 				F384BBA3261EC0DE0028A248 /* ftdebug.c in Sources */,
 				F384BDB9261EC7650028A248 /* hb-unicode.cc in Sources */,
 				F384BC66261EC1F30028A248 /* pfr.c in Sources */,
-				F384BDA1261EC7650028A248 /* hb-ot-shape-complex-indic.cc in Sources */,
 				F384BC19261EC1440028A248 /* ftbzip2.c in Sources */,
 				F384BCF2261EC5130028A248 /* ftcache.c in Sources */,
+				618705112B476C1900575B78 /* hb-ot-shaper-vowel-constraints.cc in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -814,92 +864,102 @@
 			buildActionMask = 2147483647;
 			files = (
 				F384BB8E261EC0DE0028A248 /* ftbdf.c in Sources */,
-				F384BD92261EC7650028A248 /* hb-ot-shape-complex-vowel-constraints.cc in Sources */,
 				F384BBBE261EC0DE0028A248 /* ftglyph.c in Sources */,
+				618705102B476C1900575B78 /* hb-ot-shaper-indic-table.cc in Sources */,
 				F384BC3D261EC1890028A248 /* type1cid.c in Sources */,
 				F384BC74261EC2050028A248 /* psaux.c in Sources */,
 				F384BD38261EC7650028A248 /* hb-set.cc in Sources */,
+				618704FC2B476BAD00575B78 /* hb-ot-shaper-thai.cc in Sources */,
+				618704F42B476B5800575B78 /* hb-ot-shaper-default.cc in Sources */,
+				618704E82B476A1500575B78 /* hb-outline.cc in Sources */,
+				618705192B476C8900575B78 /* hb-coretext.cc in Sources */,
 				F384BCA0261EC2680028A248 /* sfnt.c in Sources */,
 				F384BDEC261EC7650028A248 /* hb-ot-cff1-table.cc in Sources */,
-				F384BE28261EC7650028A248 /* hb-ot-shape-complex-syllabic.cc in Sources */,
-				F384BDD4261EC7650028A248 /* hb-ot-shape-complex-khmer.cc in Sources */,
 				F384BCC1261EC2980028A248 /* truetype.c in Sources */,
 				F384BD5C261EC7650028A248 /* hb-ot-map.cc in Sources */,
+				6187051B2B476C8900575B78 /* hb-directwrite.cc in Sources */,
 				F384BBDC261EC0DE0028A248 /* ftcid.c in Sources */,
 				F384BDC2261EC7650028A248 /* hb-buffer.cc in Sources */,
+				618705062B476BAD00575B78 /* hb-ot-shaper-use.cc in Sources */,
 				F384BD86261EC7650028A248 /* hb-shaper.cc in Sources */,
 				F384BCD7261EC2BE0028A248 /* type42.c in Sources */,
+				618704EE2B476A9900575B78 /* hb-buffer-verify.cc in Sources */,
 				F384BDF2261EC7650028A248 /* hb-face.cc in Sources */,
+				6187050C2B476C1900575B78 /* hb-ot-shaper-myanmar.cc in Sources */,
 				F384BCE2261EC2CF0028A248 /* winfnt.c in Sources */,
 				F384BC32261EC1710028A248 /* cff.c in Sources */,
+				6187052A2B476D2A00575B78 /* hb-cairo.cc in Sources */,
+				618705222B476CF000575B78 /* hb-ot-name.cc in Sources */,
+				618705242B476CF000575B78 /* hb-ot-color.cc in Sources */,
 				F384BDAA261EC7650028A248 /* hb-buffer-serialize.cc in Sources */,
 				F384BBC4261EC0DE0028A248 /* ftsynth.c in Sources */,
+				618705172B476C8900575B78 /* hb-draw.cc in Sources */,
 				F384BE0A261EC7650028A248 /* hb-ot-shape-normalize.cc in Sources */,
 				F384BD44261EC7650028A248 /* hb-static.cc in Sources */,
 				F384BD7A261EC7650028A248 /* hb-number.cc in Sources */,
 				F384BBD0261EC0DE0028A248 /* ftinit.c in Sources */,
 				F384BE22261EC7650028A248 /* hb-ot-shape.cc in Sources */,
-				F384BDDA261EC7650028A248 /* hb-ot-shape-complex-myanmar.cc in Sources */,
 				F384BD6E261EC7650028A248 /* hb-shape-plan.cc in Sources */,
+				618705042B476BAD00575B78 /* hb-ot-shaper-hangul.cc in Sources */,
 				F384BBB2261EC0DE0028A248 /* ftbase.c in Sources */,
 				F384BC5E261EC1DF0028A248 /* pcf.c in Sources */,
 				F384BC53261EC1B90028A248 /* ftlzw.c in Sources */,
 				F384BBF4261EC0DE0028A248 /* ftsystem.c in Sources */,
+				618705022B476BAD00575B78 /* hb-ot-shaper-hebrew.cc in Sources */,
+				618705202B476CF000575B78 /* hb-ot-meta.cc in Sources */,
 				F384BBE2261EC0DE0028A248 /* ftpfr.c in Sources */,
-				F384BDB6261EC7650028A248 /* hb-ot-shape-complex-use.cc in Sources */,
 				F384BDC8261EC7650028A248 /* hb-ot-cff2-table.cc in Sources */,
 				F384BE16261EC7650028A248 /* hb-ot-math.cc in Sources */,
 				F384BBD6261EC0DE0028A248 /* ftmm.c in Sources */,
 				F384BD74261EC7650028A248 /* hb-ot-tag.cc in Sources */,
 				F384BC06261EC0DE0028A248 /* fttype1.c in Sources */,
 				F384BBA0261EC0DE0028A248 /* ftstroke.c in Sources */,
-				F384BD62261EC7650028A248 /* hb-ot-shape-complex-hangul.cc in Sources */,
+				618705282B476D2A00575B78 /* hb-paint.cc in Sources */,
 				F384BC48261EC1A30028A248 /* ftgzip.c in Sources */,
 				F307EE2A282738F8003915D7 /* svg.c in Sources */,
 				F384BB6F261EC0760028A248 /* autofit.c in Sources */,
-				F384BD56261EC7650028A248 /* hb-ot-shape-complex-indic-table.cc in Sources */,
 				F384BDFE261EC7650028A248 /* hb-aat-map.cc in Sources */,
 				F384BB94261EC0DE0028A248 /* ftgasp.c in Sources */,
 				F384BBFA261EC0DE0028A248 /* ftwinfnt.c in Sources */,
 				BE48FD6B07AFA17000BB41DA /* SDL_ttf.c in Sources */,
-				F384BD8C261EC7650028A248 /* hb-ot-shape-complex-arabic.cc in Sources */,
 				F384BDE6261EC7650028A248 /* hb-common.cc in Sources */,
 				F384BD80261EC7650028A248 /* hb-ot-metrics.cc in Sources */,
 				F384BDE0261EC7650028A248 /* hb-aat-layout.cc in Sources */,
+				618704EB2B476A5200575B78 /* hb-paint-extents.cc in Sources */,
 				F384BDF8261EC7650028A248 /* hb-blob.cc in Sources */,
-				F384BD9E261EC7650028A248 /* hb-ot-shape-complex-thai.cc in Sources */,
 				F384BCCC261EC2AE0028A248 /* type1.c in Sources */,
 				F384BD3E261EC7650028A248 /* hb-shape.cc in Sources */,
 				F384BC95261EC2560028A248 /* raster.c in Sources */,
 				F384BDCE261EC7650028A248 /* hb-ot-face.cc in Sources */,
 				F384BB9A261EC0DE0028A248 /* ftgxval.c in Sources */,
 				F384BDB0261EC7650028A248 /* hb-font.cc in Sources */,
+				618704F12B476B1900575B78 /* hb-ot-shaper-arabic.cc in Sources */,
 				F384BD50261EC7650028A248 /* hb-ucd.cc in Sources */,
 				F384BBB8261EC0DE0028A248 /* ftpatent.c in Sources */,
+				618704FE2B476BAD00575B78 /* hb-ot-shaper-khmer.cc in Sources */,
+				6187050E2B476C1900575B78 /* hb-ot-shaper-syllabic.cc in Sources */,
 				F3696FE7278F7107003A7F94 /* sdf.c in Sources */,
 				F384BE04261EC7650028A248 /* hb-ft.cc in Sources */,
 				F384BE1C261EC7650028A248 /* hb-ot-shape-fallback.cc in Sources */,
 				F384BD98261EC7650028A248 /* hb-ot-layout.cc in Sources */,
-				F307EE2D282807EB003915D7 /* hb-ms-feature-ranges.cc in Sources */,
 				F384BC11261EC0F90028A248 /* bdf.c in Sources */,
 				F384BC8A261EC23B0028A248 /* psmodule.c in Sources */,
 				F384BE10261EC7650028A248 /* hb-ot-var.cc in Sources */,
 				F384BBE8261EC0DE0028A248 /* ftotval.c in Sources */,
-				F384BD32261EC7650028A248 /* hb-ot-shape-complex-default.cc in Sources */,
 				F384BBEE261EC0DE0028A248 /* ftfstype.c in Sources */,
 				F384BC7F261EC2180028A248 /* pshinter.c in Sources */,
 				F384BD68261EC7650028A248 /* hb-ot-font.cc in Sources */,
 				F384BBCA261EC0DE0028A248 /* ftbitmap.c in Sources */,
+				618705002B476BAD00575B78 /* hb-ot-shaper-indic.cc in Sources */,
 				F384BCAB261EC2770028A248 /* smooth.c in Sources */,
-				F384BD4A261EC7650028A248 /* hb-ot-shape-complex-hebrew.cc in Sources */,
 				F384BBAC261EC0DE0028A248 /* ftbbox.c in Sources */,
 				F384BE4B261EC9470028A248 /* hb-fallback-shape.cc in Sources */,
 				F384BBA6261EC0DE0028A248 /* ftdebug.c in Sources */,
 				F384BDBC261EC7650028A248 /* hb-unicode.cc in Sources */,
 				F384BC69261EC1F30028A248 /* pfr.c in Sources */,
-				F384BDA4261EC7650028A248 /* hb-ot-shape-complex-indic.cc in Sources */,
 				F384BC1C261EC1440028A248 /* ftbzip2.c in Sources */,
 				F384BCF5261EC5130028A248 /* ftcache.c in Sources */,
+				618705122B476C1900575B78 /* hb-ot-shaper-vowel-constraints.cc in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
The Xcode project was referring to some files that don't exist in the Harfbuzz project anymore, this commit also added some .cc files that were missing to build the library using Xcode.

This PR aims to solve this error:

```
error: Build input file cannot be found: '/Users/user-name/src/users/SDL_ttf/external/harfbuzz/src/hb-ot-shape-complex-syllabic.cc'. Did you forget to declare this file as an output of a script phase or custom build rule which produces it? (in target 'Framework' from project 'SDL_ttf')

Build input file cannot be found: '/Users/user-name/src/users/SDL_ttf/external/harfbuzz/src/hb-ot-shape-complex-syllabic.cc'. Did you forget to declare this file as an output of a script phase or custom build rule which produces it?

CompileC /Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Intermediates.noindex/SDL_ttf.build/Debug-iphoneos/Framework.build/Objects-normal/arm64/hb-ot-shape-complex-vowel-constraints.o /Users/user-name/src/users/SDL_ttf/external/harfbuzz/src/hb-ot-shape-complex-vowel-constraints.cc normal arm64 c++ com.apple.compilers.llvm.clang.1_0.compiler (in target 'Framework' from project 'SDL_ttf')
    cd /Users/user-name/src/users/SDL_ttf/Xcode
    /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang -x c++ -ivfsstatcache /Users/user-name/Library/Developer/Xcode/DerivedData/SDKStatCaches.noindex/iphoneos17.0-21A326-1e1d10ddc0bdcd738a98873f48b793a5.sdkstatcache -target arm64-apple-ios9.0 -fmessage-length\=0 -fdiagnostics-show-note-include-stack -fmacro-backtrace-limit\=0 -fno-color-diagnostics -std\=c++11 -stdlib\=libc++ -Wno-trigraphs -fpascal-strings -O0 -Wno-missing-field-initializers -Wno-missing-prototypes -Wno-return-type -Wno-non-virtual-dtor -Wno-overloaded-virtual -Wno-exit-time-destructors -Wno-missing-braces -Wparentheses -Wswitch -Wno-unused-function -Wno-unused-label -Wno-unused-parameter -Wno-unused-variable -Wunused-value -Wno-empty-body -Wno-uninitialized -Wno-unknown-pragmas -Wno-shadow -Wno-four-char-constants -Wno-conversion -Wno-constant-conversion -Wno-int-conversion -Wno-bool-conversion -Wno-enum-conversion -Wno-float-conversion -Wno-non-literal-null-conversion -Wno-objc-literal-conversion -Wshorten-64-to-32 -Wno-newline-eof -Wno-c++11-extensions -Wno-implicit-fallthrough -DFT2_BUILD_LIBRARY -DFT_PUBLIC_FUNCTION_ATTRIBUTE\= -DFT_CONFIG_OPTION_USE_HARFBUZZ -DHAVE_CONFIG_H -DTTF_USE_HARFBUZZ\=1 -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS17.0.sdk -fstrict-aliasing -Wdeprecated-declarations -Winvalid-offsetof -g -fvisibility-inlines-hidden -Wno-sign-conversion -Wno-infinite-recursion -Wno-move -Wno-comma -Wno-block-capture-autoreleasing -Wno-strict-prototypes -Wno-range-loop-analysis -Wno-semicolon-before-method-body -index-store-path /Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Index.noindex/DataStore -iquote /Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Intermediates.noindex/SDL_ttf.build/Debug-iphoneos/Framework.build/SDL2_ttf-generated-files.hmap -I/Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Intermediates.noindex/SDL_ttf.build/Debug-iphoneos/Framework.build/SDL2_ttf-own-target-headers.hmap -I/Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Intermediates.noindex/SDL_ttf.build/Debug-iphoneos/Framework.build/SDL2_ttf-all-target-headers.hmap -iquote /Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Intermediates.noindex/SDL_ttf.build/Debug-iphoneos/Framework.build/SDL2_ttf-project-headers.hmap -I/Users/user-name/src/users/SDL_ttf/external/freetype/include -I/Users/user-name/src/users/SDL_ttf/external/harfbuzz -I/Users/user-name/src/users/SDL_ttf/external/harfbuzz/src -I/Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Products/Debug-iphoneos/include -I/Users/user-name/src/users/SDL_ttf/Xcode/iOS/SDL2.framework/Headers -I/Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Intermediates.noindex/SDL_ttf.build/Debug-iphoneos/Framework.build/DerivedSources-normal/arm64 -I/Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Intermediates.noindex/SDL_ttf.build/Debug-iphoneos/Framework.build/DerivedSources/arm64 -I/Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Intermediates.noindex/SDL_ttf.build/Debug-iphoneos/Framework.build/DerivedSources -F/Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Products/Debug-iphoneos -F/Users/user-name/src/users/SDL_ttf/Xcode/iOS -MMD -MT dependencies -MF /Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Intermediates.noindex/SDL_ttf.build/Debug-iphoneos/Framework.build/Objects-normal/arm64/hb-ot-shape-complex-vowel-constraints.d --serialize-diagnostics /Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Intermediates.noindex/SDL_ttf.build/Debug-iphoneos/Framework.build/Objects-normal/arm64/hb-ot-shape-complex-vowel-constraints.dia -c /Users/user-name/src/users/SDL_ttf/external/harfbuzz/src/hb-ot-shape-complex-vowel-constraints.cc -o /Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Intermediates.noindex/SDL_ttf.build/Debug-iphoneos/Framework.build/Objects-normal/arm64/hb-ot-shape-complex-vowel-constraints.o -index-unit-output-path /SDL_ttf.build/Debug-iphoneos/Framework.build/Objects-normal/arm64/hb-ot-shape-complex-vowel-constraints.o
```

<details>
  <summary>Click here for the whole log</summary>

  ```

Showing Recent Messages

Prepare build
note: Removed stale file '/Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Intermediates.noindex/SDL_ttf.build/Debug-iphoneos/Framework.build/Objects-normal/arm64/hb-buffer-verify.o'

note: Removed stale file '/Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Intermediates.noindex/SDL_ttf.build/Debug-iphoneos/Framework.build/Objects-normal/arm64/hb-cairo.o'

note: Removed stale file '/Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Intermediates.noindex/SDL_ttf.build/Debug-iphoneos/Framework.build/Objects-normal/arm64/hb-coretext.o'

note: Removed stale file '/Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Intermediates.noindex/SDL_ttf.build/Debug-iphoneos/Framework.build/Objects-normal/arm64/hb-directwrite.o'

note: Removed stale file '/Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Intermediates.noindex/SDL_ttf.build/Debug-iphoneos/Framework.build/Objects-normal/arm64/hb-draw.o'

note: Removed stale file '/Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Intermediates.noindex/SDL_ttf.build/Debug-iphoneos/Framework.build/Objects-normal/arm64/hb-ot-color.o'

note: Removed stale file '/Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Intermediates.noindex/SDL_ttf.build/Debug-iphoneos/Framework.build/Objects-normal/arm64/hb-ot-meta.o'

note: Removed stale file '/Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Intermediates.noindex/SDL_ttf.build/Debug-iphoneos/Framework.build/Objects-normal/arm64/hb-ot-name.o'

note: Removed stale file '/Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Intermediates.noindex/SDL_ttf.build/Debug-iphoneos/Framework.build/Objects-normal/arm64/hb-ot-shaper-arabic.o'

note: Removed stale file '/Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Intermediates.noindex/SDL_ttf.build/Debug-iphoneos/Framework.build/Objects-normal/arm64/hb-ot-shaper-default.o'

note: Removed stale file '/Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Intermediates.noindex/SDL_ttf.build/Debug-iphoneos/Framework.build/Objects-normal/arm64/hb-ot-shaper-hangul.o'

note: Removed stale file '/Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Intermediates.noindex/SDL_ttf.build/Debug-iphoneos/Framework.build/Objects-normal/arm64/hb-ot-shaper-hebrew.o'

note: Removed stale file '/Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Intermediates.noindex/SDL_ttf.build/Debug-iphoneos/Framework.build/Objects-normal/arm64/hb-ot-shaper-indic-table.o'

note: Removed stale file '/Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Intermediates.noindex/SDL_ttf.build/Debug-iphoneos/Framework.build/Objects-normal/arm64/hb-ot-shaper-indic.o'

note: Removed stale file '/Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Intermediates.noindex/SDL_ttf.build/Debug-iphoneos/Framework.build/Objects-normal/arm64/hb-ot-shaper-khmer.o'

note: Removed stale file '/Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Intermediates.noindex/SDL_ttf.build/Debug-iphoneos/Framework.build/Objects-normal/arm64/hb-ot-shaper-myanmar.o'

note: Removed stale file '/Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Intermediates.noindex/SDL_ttf.build/Debug-iphoneos/Framework.build/Objects-normal/arm64/hb-ot-shaper-syllabic.o'

note: Removed stale file '/Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Intermediates.noindex/SDL_ttf.build/Debug-iphoneos/Framework.build/Objects-normal/arm64/hb-ot-shaper-thai.o'

note: Removed stale file '/Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Intermediates.noindex/SDL_ttf.build/Debug-iphoneos/Framework.build/Objects-normal/arm64/hb-ot-shaper-use.o'

note: Removed stale file '/Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Intermediates.noindex/SDL_ttf.build/Debug-iphoneos/Framework.build/Objects-normal/arm64/hb-ot-shaper-vowel-constraints.o'

note: Removed stale file '/Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Intermediates.noindex/SDL_ttf.build/Debug-iphoneos/Framework.build/Objects-normal/arm64/hb-outline.o'

note: Removed stale file '/Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Intermediates.noindex/SDL_ttf.build/Debug-iphoneos/Framework.build/Objects-normal/arm64/hb-paint-extents.o'

note: Removed stale file '/Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Intermediates.noindex/SDL_ttf.build/Debug-iphoneos/Framework.build/Objects-normal/arm64/hb-paint.o'



Removed stale file '/Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Intermediates.noindex/SDL_ttf.build/Debug-iphoneos/Framework.build/Objects-normal/arm64/hb-buffer-verify.o'


Removed stale file '/Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Intermediates.noindex/SDL_ttf.build/Debug-iphoneos/Framework.build/Objects-normal/arm64/hb-cairo.o'


Removed stale file '/Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Intermediates.noindex/SDL_ttf.build/Debug-iphoneos/Framework.build/Objects-normal/arm64/hb-coretext.o'


Removed stale file '/Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Intermediates.noindex/SDL_ttf.build/Debug-iphoneos/Framework.build/Objects-normal/arm64/hb-directwrite.o'


Removed stale file '/Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Intermediates.noindex/SDL_ttf.build/Debug-iphoneos/Framework.build/Objects-normal/arm64/hb-draw.o'


Removed stale file '/Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Intermediates.noindex/SDL_ttf.build/Debug-iphoneos/Framework.build/Objects-normal/arm64/hb-ot-color.o'


Removed stale file '/Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Intermediates.noindex/SDL_ttf.build/Debug-iphoneos/Framework.build/Objects-normal/arm64/hb-ot-meta.o'


Removed stale file '/Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Intermediates.noindex/SDL_ttf.build/Debug-iphoneos/Framework.build/Objects-normal/arm64/hb-ot-name.o'


Removed stale file '/Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Intermediates.noindex/SDL_ttf.build/Debug-iphoneos/Framework.build/Objects-normal/arm64/hb-ot-shaper-arabic.o'


Removed stale file '/Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Intermediates.noindex/SDL_ttf.build/Debug-iphoneos/Framework.build/Objects-normal/arm64/hb-ot-shaper-default.o'


Removed stale file '/Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Intermediates.noindex/SDL_ttf.build/Debug-iphoneos/Framework.build/Objects-normal/arm64/hb-ot-shaper-hangul.o'


Removed stale file '/Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Intermediates.noindex/SDL_ttf.build/Debug-iphoneos/Framework.build/Objects-normal/arm64/hb-ot-shaper-hebrew.o'


Removed stale file '/Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Intermediates.noindex/SDL_ttf.build/Debug-iphoneos/Framework.build/Objects-normal/arm64/hb-ot-shaper-indic-table.o'


Removed stale file '/Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Intermediates.noindex/SDL_ttf.build/Debug-iphoneos/Framework.build/Objects-normal/arm64/hb-ot-shaper-indic.o'


Removed stale file '/Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Intermediates.noindex/SDL_ttf.build/Debug-iphoneos/Framework.build/Objects-normal/arm64/hb-ot-shaper-khmer.o'


Removed stale file '/Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Intermediates.noindex/SDL_ttf.build/Debug-iphoneos/Framework.build/Objects-normal/arm64/hb-ot-shaper-myanmar.o'


Removed stale file '/Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Intermediates.noindex/SDL_ttf.build/Debug-iphoneos/Framework.build/Objects-normal/arm64/hb-ot-shaper-syllabic.o'


Removed stale file '/Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Intermediates.noindex/SDL_ttf.build/Debug-iphoneos/Framework.build/Objects-normal/arm64/hb-ot-shaper-thai.o'


Removed stale file '/Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Intermediates.noindex/SDL_ttf.build/Debug-iphoneos/Framework.build/Objects-normal/arm64/hb-ot-shaper-use.o'


Removed stale file '/Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Intermediates.noindex/SDL_ttf.build/Debug-iphoneos/Framework.build/Objects-normal/arm64/hb-ot-shaper-vowel-constraints.o'


Removed stale file '/Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Intermediates.noindex/SDL_ttf.build/Debug-iphoneos/Framework.build/Objects-normal/arm64/hb-outline.o'


Removed stale file '/Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Intermediates.noindex/SDL_ttf.build/Debug-iphoneos/Framework.build/Objects-normal/arm64/hb-paint-extents.o'


Removed stale file '/Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Intermediates.noindex/SDL_ttf.build/Debug-iphoneos/Framework.build/Objects-normal/arm64/hb-paint.o'


ComputeTargetDependencyGraph

note: Building targets in dependency order
note: Target dependency graph (1 target)
    Target 'Framework' in project 'SDL_ttf' (no dependencies)

Building targets in dependency order

Target dependency graph (1 target)

GatherProvisioningInputs

CreateBuildDescription

Build description signature: b3210ff21aaf3f342988efe672853d71
Build description path: /Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Intermediates.noindex/XCBuildData/b3210ff21aaf3f342988efe672853d71.xcbuilddata

ClangStatCache /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang-stat-cache /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS17.0.sdk /Users/user-name/Library/Developer/Xcode/DerivedData/SDKStatCaches.noindex/iphoneos17.0-21A326-1e1d10ddc0bdcd738a98873f48b793a5.sdkstatcache
    cd /Users/user-name/src/users/SDL_ttf/Xcode/SDL_ttf.xcodeproj
    /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang-stat-cache /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS17.0.sdk -o /Users/user-name/Library/Developer/Xcode/DerivedData/SDKStatCaches.noindex/iphoneos17.0-21A326-1e1d10ddc0bdcd738a98873f48b793a5.sdkstatcache


Build target Framework of project SDL_ttf with configuration Debug
/Users/user-name/src/users/SDL_ttf/Xcode/SDL_ttf.xcodeproj: warning: The iOS deployment target 'IPHONEOS_DEPLOYMENT_TARGET' is set to 9.0, but the range of supported deployment target versions is 12.0 to 17.0.99. (in target 'Framework' from project 'SDL_ttf')
warning: Traditional headermap style is no longer supported; please migrate to using separate headermaps and set 'ALWAYS_SEARCH_USER_PATHS' to NO. (in target 'Framework' from project 'SDL_ttf')
warning: Build Carbon Resources build phases are no longer supported.  Rez source files should be moved to the Copy Bundle Resources build phase. (in target 'Framework' from project 'SDL_ttf')
warning: Run script build phase 'Convert SDL includes to SDL Framework includes' will be run during every build because it does not specify any outputs. To address this warning, either add output dependencies to the script phase, or configure it to run in every build by unchecking "Based on dependency analysis" in the script phase. (in target 'Framework' from project 'SDL_ttf')


/Users/user-name/src/users/SDL_ttf/Xcode/SDL_ttf.xcodeproj: The iOS deployment target 'IPHONEOS_DEPLOYMENT_TARGET' is set to 9.0, but the range of supported deployment target versions is 12.0 to 17.0.99.

Traditional headermap style is no longer supported; please migrate to using separate headermaps and set 'ALWAYS_SEARCH_USER_PATHS' to NO.

Build Carbon Resources build phases are no longer supported.  Rez source files should be moved to the Copy Bundle Resources build phase.

Run script build phase 'Convert SDL includes to SDL Framework includes' will be run during every build because it does not specify any outputs. To address this warning, either add output dependencies to the script phase, or configure it to run in every build by unchecking "Based on dependency analysis" in the script phase.

CpHeader /Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Products/Debug-iphoneos/SDL2_ttf.framework/Headers/SDL_ttf.h /Users/user-name/src/users/SDL_ttf/SDL_ttf.h (in target 'Framework' from project 'SDL_ttf')
    cd /Users/user-name/src/users/SDL_ttf/Xcode
    builtin-copy -exclude .DS_Store -exclude CVS -exclude .svn -exclude .git -exclude .hg -resolve-src-symlinks /Users/user-name/src/users/SDL_ttf/SDL_ttf.h /Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Products/Debug-iphoneos/SDL2_ttf.framework/Headers

WriteAuxiliaryFile /Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Intermediates.noindex/SDL_ttf.build/Debug-iphoneos/Framework.build/Objects-normal/arm64/SDL2_ttf.LinkFileList (in target 'Framework' from project 'SDL_ttf')
    cd /Users/user-name/src/users/SDL_ttf/Xcode
    write-file /Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Intermediates.noindex/SDL_ttf.build/Debug-iphoneos/Framework.build/Objects-normal/arm64/SDL2_ttf.LinkFileList

CompileC /Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Intermediates.noindex/SDL_ttf.build/Debug-iphoneos/Framework.build/Objects-normal/arm64/hb-ot-shape-complex-indic.o /Users/user-name/src/users/SDL_ttf/external/harfbuzz/src/hb-ot-shape-complex-indic.cc normal arm64 c++ com.apple.compilers.llvm.clang.1_0.compiler (in target 'Framework' from project 'SDL_ttf')
    cd /Users/user-name/src/users/SDL_ttf/Xcode
    /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang -x c++ -ivfsstatcache /Users/user-name/Library/Developer/Xcode/DerivedData/SDKStatCaches.noindex/iphoneos17.0-21A326-1e1d10ddc0bdcd738a98873f48b793a5.sdkstatcache -target arm64-apple-ios9.0 -fmessage-length\=0 -fdiagnostics-show-note-include-stack -fmacro-backtrace-limit\=0 -fno-color-diagnostics -std\=c++11 -stdlib\=libc++ -Wno-trigraphs -fpascal-strings -O0 -Wno-missing-field-initializers -Wno-missing-prototypes -Wno-return-type -Wno-non-virtual-dtor -Wno-overloaded-virtual -Wno-exit-time-destructors -Wno-missing-braces -Wparentheses -Wswitch -Wno-unused-function -Wno-unused-label -Wno-unused-parameter -Wno-unused-variable -Wunused-value -Wno-empty-body -Wno-uninitialized -Wno-unknown-pragmas -Wno-shadow -Wno-four-char-constants -Wno-conversion -Wno-constant-conversion -Wno-int-conversion -Wno-bool-conversion -Wno-enum-conversion -Wno-float-conversion -Wno-non-literal-null-conversion -Wno-objc-literal-conversion -Wshorten-64-to-32 -Wno-newline-eof -Wno-c++11-extensions -Wno-implicit-fallthrough -DFT2_BUILD_LIBRARY -DFT_PUBLIC_FUNCTION_ATTRIBUTE\= -DFT_CONFIG_OPTION_USE_HARFBUZZ -DHAVE_CONFIG_H -DTTF_USE_HARFBUZZ\=1 -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS17.0.sdk -fstrict-aliasing -Wdeprecated-declarations -Winvalid-offsetof -g -fvisibility-inlines-hidden -Wno-sign-conversion -Wno-infinite-recursion -Wno-move -Wno-comma -Wno-block-capture-autoreleasing -Wno-strict-prototypes -Wno-range-loop-analysis -Wno-semicolon-before-method-body -index-store-path /Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Index.noindex/DataStore -iquote /Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Intermediates.noindex/SDL_ttf.build/Debug-iphoneos/Framework.build/SDL2_ttf-generated-files.hmap -I/Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Intermediates.noindex/SDL_ttf.build/Debug-iphoneos/Framework.build/SDL2_ttf-own-target-headers.hmap -I/Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Intermediates.noindex/SDL_ttf.build/Debug-iphoneos/Framework.build/SDL2_ttf-all-target-headers.hmap -iquote /Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Intermediates.noindex/SDL_ttf.build/Debug-iphoneos/Framework.build/SDL2_ttf-project-headers.hmap -I/Users/user-name/src/users/SDL_ttf/external/freetype/include -I/Users/user-name/src/users/SDL_ttf/external/harfbuzz -I/Users/user-name/src/users/SDL_ttf/external/harfbuzz/src -I/Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Products/Debug-iphoneos/include -I/Users/user-name/src/users/SDL_ttf/Xcode/iOS/SDL2.framework/Headers -I/Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Intermediates.noindex/SDL_ttf.build/Debug-iphoneos/Framework.build/DerivedSources-normal/arm64 -I/Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Intermediates.noindex/SDL_ttf.build/Debug-iphoneos/Framework.build/DerivedSources/arm64 -I/Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Intermediates.noindex/SDL_ttf.build/Debug-iphoneos/Framework.build/DerivedSources -F/Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Products/Debug-iphoneos -F/Users/user-name/src/users/SDL_ttf/Xcode/iOS -MMD -MT dependencies -MF /Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Intermediates.noindex/SDL_ttf.build/Debug-iphoneos/Framework.build/Objects-normal/arm64/hb-ot-shape-complex-indic.d --serialize-diagnostics /Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Intermediates.noindex/SDL_ttf.build/Debug-iphoneos/Framework.build/Objects-normal/arm64/hb-ot-shape-complex-indic.dia -c /Users/user-name/src/users/SDL_ttf/external/harfbuzz/src/hb-ot-shape-complex-indic.cc -o /Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Intermediates.noindex/SDL_ttf.build/Debug-iphoneos/Framework.build/Objects-normal/arm64/hb-ot-shape-complex-indic.o -index-unit-output-path /SDL_ttf.build/Debug-iphoneos/Framework.build/Objects-normal/arm64/hb-ot-shape-complex-indic.o

error: Build input file cannot be found: '/Users/user-name/src/users/SDL_ttf/external/harfbuzz/src/hb-ot-shape-complex-indic.cc'. Did you forget to declare this file as an output of a script phase or custom build rule which produces it? (in target 'Framework' from project 'SDL_ttf')

Build input file cannot be found: '/Users/user-name/src/users/SDL_ttf/external/harfbuzz/src/hb-ot-shape-complex-indic.cc'. Did you forget to declare this file as an output of a script phase or custom build rule which produces it?

CompileC /Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Intermediates.noindex/SDL_ttf.build/Debug-iphoneos/Framework.build/Objects-normal/arm64/hb-ot-shape-complex-hebrew.o /Users/user-name/src/users/SDL_ttf/external/harfbuzz/src/hb-ot-shape-complex-hebrew.cc normal arm64 c++ com.apple.compilers.llvm.clang.1_0.compiler (in target 'Framework' from project 'SDL_ttf')
    cd /Users/user-name/src/users/SDL_ttf/Xcode
    /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang -x c++ -ivfsstatcache /Users/user-name/Library/Developer/Xcode/DerivedData/SDKStatCaches.noindex/iphoneos17.0-21A326-1e1d10ddc0bdcd738a98873f48b793a5.sdkstatcache -target arm64-apple-ios9.0 -fmessage-length\=0 -fdiagnostics-show-note-include-stack -fmacro-backtrace-limit\=0 -fno-color-diagnostics -std\=c++11 -stdlib\=libc++ -Wno-trigraphs -fpascal-strings -O0 -Wno-missing-field-initializers -Wno-missing-prototypes -Wno-return-type -Wno-non-virtual-dtor -Wno-overloaded-virtual -Wno-exit-time-destructors -Wno-missing-braces -Wparentheses -Wswitch -Wno-unused-function -Wno-unused-label -Wno-unused-parameter -Wno-unused-variable -Wunused-value -Wno-empty-body -Wno-uninitialized -Wno-unknown-pragmas -Wno-shadow -Wno-four-char-constants -Wno-conversion -Wno-constant-conversion -Wno-int-conversion -Wno-bool-conversion -Wno-enum-conversion -Wno-float-conversion -Wno-non-literal-null-conversion -Wno-objc-literal-conversion -Wshorten-64-to-32 -Wno-newline-eof -Wno-c++11-extensions -Wno-implicit-fallthrough -DFT2_BUILD_LIBRARY -DFT_PUBLIC_FUNCTION_ATTRIBUTE\= -DFT_CONFIG_OPTION_USE_HARFBUZZ -DHAVE_CONFIG_H -DTTF_USE_HARFBUZZ\=1 -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS17.0.sdk -fstrict-aliasing -Wdeprecated-declarations -Winvalid-offsetof -g -fvisibility-inlines-hidden -Wno-sign-conversion -Wno-infinite-recursion -Wno-move -Wno-comma -Wno-block-capture-autoreleasing -Wno-strict-prototypes -Wno-range-loop-analysis -Wno-semicolon-before-method-body -index-store-path /Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Index.noindex/DataStore -iquote /Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Intermediates.noindex/SDL_ttf.build/Debug-iphoneos/Framework.build/SDL2_ttf-generated-files.hmap -I/Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Intermediates.noindex/SDL_ttf.build/Debug-iphoneos/Framework.build/SDL2_ttf-own-target-headers.hmap -I/Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Intermediates.noindex/SDL_ttf.build/Debug-iphoneos/Framework.build/SDL2_ttf-all-target-headers.hmap -iquote /Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Intermediates.noindex/SDL_ttf.build/Debug-iphoneos/Framework.build/SDL2_ttf-project-headers.hmap -I/Users/user-name/src/users/SDL_ttf/external/freetype/include -I/Users/user-name/src/users/SDL_ttf/external/harfbuzz -I/Users/user-name/src/users/SDL_ttf/external/harfbuzz/src -I/Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Products/Debug-iphoneos/include -I/Users/user-name/src/users/SDL_ttf/Xcode/iOS/SDL2.framework/Headers -I/Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Intermediates.noindex/SDL_ttf.build/Debug-iphoneos/Framework.build/DerivedSources-normal/arm64 -I/Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Intermediates.noindex/SDL_ttf.build/Debug-iphoneos/Framework.build/DerivedSources/arm64 -I/Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Intermediates.noindex/SDL_ttf.build/Debug-iphoneos/Framework.build/DerivedSources -F/Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Products/Debug-iphoneos -F/Users/user-name/src/users/SDL_ttf/Xcode/iOS -MMD -MT dependencies -MF /Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Intermediates.noindex/SDL_ttf.build/Debug-iphoneos/Framework.build/Objects-normal/arm64/hb-ot-shape-complex-hebrew.d --serialize-diagnostics /Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Intermediates.noindex/SDL_ttf.build/Debug-iphoneos/Framework.build/Objects-normal/arm64/hb-ot-shape-complex-hebrew.dia -c /Users/user-name/src/users/SDL_ttf/external/harfbuzz/src/hb-ot-shape-complex-hebrew.cc -o /Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Intermediates.noindex/SDL_ttf.build/Debug-iphoneos/Framework.build/Objects-normal/arm64/hb-ot-shape-complex-hebrew.o -index-unit-output-path /SDL_ttf.build/Debug-iphoneos/Framework.build/Objects-normal/arm64/hb-ot-shape-complex-hebrew.o

error: Build input file cannot be found: '/Users/user-name/src/users/SDL_ttf/external/harfbuzz/src/hb-ot-shape-complex-hebrew.cc'. Did you forget to declare this file as an output of a script phase or custom build rule which produces it? (in target 'Framework' from project 'SDL_ttf')

Build input file cannot be found: '/Users/user-name/src/users/SDL_ttf/external/harfbuzz/src/hb-ot-shape-complex-hebrew.cc'. Did you forget to declare this file as an output of a script phase or custom build rule which produces it?

CompileC /Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Intermediates.noindex/SDL_ttf.build/Debug-iphoneos/Framework.build/Objects-normal/arm64/hb-ot-shape-complex-default.o /Users/user-name/src/users/SDL_ttf/external/harfbuzz/src/hb-ot-shape-complex-default.cc normal arm64 c++ com.apple.compilers.llvm.clang.1_0.compiler (in target 'Framework' from project 'SDL_ttf')
    cd /Users/user-name/src/users/SDL_ttf/Xcode
    /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang -x c++ -ivfsstatcache /Users/user-name/Library/Developer/Xcode/DerivedData/SDKStatCaches.noindex/iphoneos17.0-21A326-1e1d10ddc0bdcd738a98873f48b793a5.sdkstatcache -target arm64-apple-ios9.0 -fmessage-length\=0 -fdiagnostics-show-note-include-stack -fmacro-backtrace-limit\=0 -fno-color-diagnostics -std\=c++11 -stdlib\=libc++ -Wno-trigraphs -fpascal-strings -O0 -Wno-missing-field-initializers -Wno-missing-prototypes -Wno-return-type -Wno-non-virtual-dtor -Wno-overloaded-virtual -Wno-exit-time-destructors -Wno-missing-braces -Wparentheses -Wswitch -Wno-unused-function -Wno-unused-label -Wno-unused-parameter -Wno-unused-variable -Wunused-value -Wno-empty-body -Wno-uninitialized -Wno-unknown-pragmas -Wno-shadow -Wno-four-char-constants -Wno-conversion -Wno-constant-conversion -Wno-int-conversion -Wno-bool-conversion -Wno-enum-conversion -Wno-float-conversion -Wno-non-literal-null-conversion -Wno-objc-literal-conversion -Wshorten-64-to-32 -Wno-newline-eof -Wno-c++11-extensions -Wno-implicit-fallthrough -DFT2_BUILD_LIBRARY -DFT_PUBLIC_FUNCTION_ATTRIBUTE\= -DFT_CONFIG_OPTION_USE_HARFBUZZ -DHAVE_CONFIG_H -DTTF_USE_HARFBUZZ\=1 -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS17.0.sdk -fstrict-aliasing -Wdeprecated-declarations -Winvalid-offsetof -g -fvisibility-inlines-hidden -Wno-sign-conversion -Wno-infinite-recursion -Wno-move -Wno-comma -Wno-block-capture-autoreleasing -Wno-strict-prototypes -Wno-range-loop-analysis -Wno-semicolon-before-method-body -index-store-path /Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Index.noindex/DataStore -iquote /Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Intermediates.noindex/SDL_ttf.build/Debug-iphoneos/Framework.build/SDL2_ttf-generated-files.hmap -I/Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Intermediates.noindex/SDL_ttf.build/Debug-iphoneos/Framework.build/SDL2_ttf-own-target-headers.hmap -I/Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Intermediates.noindex/SDL_ttf.build/Debug-iphoneos/Framework.build/SDL2_ttf-all-target-headers.hmap -iquote /Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Intermediates.noindex/SDL_ttf.build/Debug-iphoneos/Framework.build/SDL2_ttf-project-headers.hmap -I/Users/user-name/src/users/SDL_ttf/external/freetype/include -I/Users/user-name/src/users/SDL_ttf/external/harfbuzz -I/Users/user-name/src/users/SDL_ttf/external/harfbuzz/src -I/Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Products/Debug-iphoneos/include -I/Users/user-name/src/users/SDL_ttf/Xcode/iOS/SDL2.framework/Headers -I/Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Intermediates.noindex/SDL_ttf.build/Debug-iphoneos/Framework.build/DerivedSources-normal/arm64 -I/Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Intermediates.noindex/SDL_ttf.build/Debug-iphoneos/Framework.build/DerivedSources/arm64 -I/Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Intermediates.noindex/SDL_ttf.build/Debug-iphoneos/Framework.build/DerivedSources -F/Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Products/Debug-iphoneos -F/Users/user-name/src/users/SDL_ttf/Xcode/iOS -MMD -MT dependencies -MF /Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Intermediates.noindex/SDL_ttf.build/Debug-iphoneos/Framework.build/Objects-normal/arm64/hb-ot-shape-complex-default.d --serialize-diagnostics /Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Intermediates.noindex/SDL_ttf.build/Debug-iphoneos/Framework.build/Objects-normal/arm64/hb-ot-shape-complex-default.dia -c /Users/user-name/src/users/SDL_ttf/external/harfbuzz/src/hb-ot-shape-complex-default.cc -o /Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Intermediates.noindex/SDL_ttf.build/Debug-iphoneos/Framework.build/Objects-normal/arm64/hb-ot-shape-complex-default.o -index-unit-output-path /SDL_ttf.build/Debug-iphoneos/Framework.build/Objects-normal/arm64/hb-ot-shape-complex-default.o

error: Build input file cannot be found: '/Users/user-name/src/users/SDL_ttf/external/harfbuzz/src/hb-ot-shape-complex-default.cc'. Did you forget to declare this file as an output of a script phase or custom build rule which produces it? (in target 'Framework' from project 'SDL_ttf')

Build input file cannot be found: '/Users/user-name/src/users/SDL_ttf/external/harfbuzz/src/hb-ot-shape-complex-default.cc'. Did you forget to declare this file as an output of a script phase or custom build rule which produces it?

CompileC /Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Intermediates.noindex/SDL_ttf.build/Debug-iphoneos/Framework.build/Objects-normal/arm64/hb-ot-shape-complex-arabic.o /Users/user-name/src/users/SDL_ttf/external/harfbuzz/src/hb-ot-shape-complex-arabic.cc normal arm64 c++ com.apple.compilers.llvm.clang.1_0.compiler (in target 'Framework' from project 'SDL_ttf')
    cd /Users/user-name/src/users/SDL_ttf/Xcode
    /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang -x c++ -ivfsstatcache /Users/user-name/Library/Developer/Xcode/DerivedData/SDKStatCaches.noindex/iphoneos17.0-21A326-1e1d10ddc0bdcd738a98873f48b793a5.sdkstatcache -target arm64-apple-ios9.0 -fmessage-length\=0 -fdiagnostics-show-note-include-stack -fmacro-backtrace-limit\=0 -fno-color-diagnostics -std\=c++11 -stdlib\=libc++ -Wno-trigraphs -fpascal-strings -O0 -Wno-missing-field-initializers -Wno-missing-prototypes -Wno-return-type -Wno-non-virtual-dtor -Wno-overloaded-virtual -Wno-exit-time-destructors -Wno-missing-braces -Wparentheses -Wswitch -Wno-unused-function -Wno-unused-label -Wno-unused-parameter -Wno-unused-variable -Wunused-value -Wno-empty-body -Wno-uninitialized -Wno-unknown-pragmas -Wno-shadow -Wno-four-char-constants -Wno-conversion -Wno-constant-conversion -Wno-int-conversion -Wno-bool-conversion -Wno-enum-conversion -Wno-float-conversion -Wno-non-literal-null-conversion -Wno-objc-literal-conversion -Wshorten-64-to-32 -Wno-newline-eof -Wno-c++11-extensions -Wno-implicit-fallthrough -DFT2_BUILD_LIBRARY -DFT_PUBLIC_FUNCTION_ATTRIBUTE\= -DFT_CONFIG_OPTION_USE_HARFBUZZ -DHAVE_CONFIG_H -DTTF_USE_HARFBUZZ\=1 -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS17.0.sdk -fstrict-aliasing -Wdeprecated-declarations -Winvalid-offsetof -g -fvisibility-inlines-hidden -Wno-sign-conversion -Wno-infinite-recursion -Wno-move -Wno-comma -Wno-block-capture-autoreleasing -Wno-strict-prototypes -Wno-range-loop-analysis -Wno-semicolon-before-method-body -index-store-path /Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Index.noindex/DataStore -iquote /Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Intermediates.noindex/SDL_ttf.build/Debug-iphoneos/Framework.build/SDL2_ttf-generated-files.hmap -I/Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Intermediates.noindex/SDL_ttf.build/Debug-iphoneos/Framework.build/SDL2_ttf-own-target-headers.hmap -I/Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Intermediates.noindex/SDL_ttf.build/Debug-iphoneos/Framework.build/SDL2_ttf-all-target-headers.hmap -iquote /Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Intermediates.noindex/SDL_ttf.build/Debug-iphoneos/Framework.build/SDL2_ttf-project-headers.hmap -I/Users/user-name/src/users/SDL_ttf/external/freetype/include -I/Users/user-name/src/users/SDL_ttf/external/harfbuzz -I/Users/user-name/src/users/SDL_ttf/external/harfbuzz/src -I/Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Products/Debug-iphoneos/include -I/Users/user-name/src/users/SDL_ttf/Xcode/iOS/SDL2.framework/Headers -I/Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Intermediates.noindex/SDL_ttf.build/Debug-iphoneos/Framework.build/DerivedSources-normal/arm64 -I/Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Intermediates.noindex/SDL_ttf.build/Debug-iphoneos/Framework.build/DerivedSources/arm64 -I/Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Intermediates.noindex/SDL_ttf.build/Debug-iphoneos/Framework.build/DerivedSources -F/Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Products/Debug-iphoneos -F/Users/user-name/src/users/SDL_ttf/Xcode/iOS -MMD -MT dependencies -MF /Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Intermediates.noindex/SDL_ttf.build/Debug-iphoneos/Framework.build/Objects-normal/arm64/hb-ot-shape-complex-arabic.d --serialize-diagnostics /Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Intermediates.noindex/SDL_ttf.build/Debug-iphoneos/Framework.build/Objects-normal/arm64/hb-ot-shape-complex-arabic.dia -c /Users/user-name/src/users/SDL_ttf/external/harfbuzz/src/hb-ot-shape-complex-arabic.cc -o /Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Intermediates.noindex/SDL_ttf.build/Debug-iphoneos/Framework.build/Objects-normal/arm64/hb-ot-shape-complex-arabic.o -index-unit-output-path /SDL_ttf.build/Debug-iphoneos/Framework.build/Objects-normal/arm64/hb-ot-shape-complex-arabic.o

error: Build input file cannot be found: '/Users/user-name/src/users/SDL_ttf/external/harfbuzz/src/hb-ot-shape-complex-arabic.cc'. Did you forget to declare this file as an output of a script phase or custom build rule which produces it? (in target 'Framework' from project 'SDL_ttf')

Build input file cannot be found: '/Users/user-name/src/users/SDL_ttf/external/harfbuzz/src/hb-ot-shape-complex-arabic.cc'. Did you forget to declare this file as an output of a script phase or custom build rule which produces it?

CompileC /Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Intermediates.noindex/SDL_ttf.build/Debug-iphoneos/Framework.build/Objects-normal/arm64/hb-ms-feature-ranges.o /Users/user-name/src/users/SDL_ttf/external/harfbuzz/src/hb-ms-feature-ranges.cc normal arm64 c++ com.apple.compilers.llvm.clang.1_0.compiler (in target 'Framework' from project 'SDL_ttf')
    cd /Users/user-name/src/users/SDL_ttf/Xcode
    /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang -x c++ -ivfsstatcache /Users/user-name/Library/Developer/Xcode/DerivedData/SDKStatCaches.noindex/iphoneos17.0-21A326-1e1d10ddc0bdcd738a98873f48b793a5.sdkstatcache -target arm64-apple-ios9.0 -fmessage-length\=0 -fdiagnostics-show-note-include-stack -fmacro-backtrace-limit\=0 -fno-color-diagnostics -std\=c++11 -stdlib\=libc++ -Wno-trigraphs -fpascal-strings -O0 -Wno-missing-field-initializers -Wno-missing-prototypes -Wno-return-type -Wno-non-virtual-dtor -Wno-overloaded-virtual -Wno-exit-time-destructors -Wno-missing-braces -Wparentheses -Wswitch -Wno-unused-function -Wno-unused-label -Wno-unused-parameter -Wno-unused-variable -Wunused-value -Wno-empty-body -Wno-uninitialized -Wno-unknown-pragmas -Wno-shadow -Wno-four-char-constants -Wno-conversion -Wno-constant-conversion -Wno-int-conversion -Wno-bool-conversion -Wno-enum-conversion -Wno-float-conversion -Wno-non-literal-null-conversion -Wno-objc-literal-conversion -Wshorten-64-to-32 -Wno-newline-eof -Wno-c++11-extensions -Wno-implicit-fallthrough -DFT2_BUILD_LIBRARY -DFT_PUBLIC_FUNCTION_ATTRIBUTE\= -DFT_CONFIG_OPTION_USE_HARFBUZZ -DHAVE_CONFIG_H -DTTF_USE_HARFBUZZ\=1 -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS17.0.sdk -fstrict-aliasing -Wdeprecated-declarations -Winvalid-offsetof -g -fvisibility-inlines-hidden -Wno-sign-conversion -Wno-infinite-recursion -Wno-move -Wno-comma -Wno-block-capture-autoreleasing -Wno-strict-prototypes -Wno-range-loop-analysis -Wno-semicolon-before-method-body -index-store-path /Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Index.noindex/DataStore -iquote /Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Intermediates.noindex/SDL_ttf.build/Debug-iphoneos/Framework.build/SDL2_ttf-generated-files.hmap -I/Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Intermediates.noindex/SDL_ttf.build/Debug-iphoneos/Framework.build/SDL2_ttf-own-target-headers.hmap -I/Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Intermediates.noindex/SDL_ttf.build/Debug-iphoneos/Framework.build/SDL2_ttf-all-target-headers.hmap -iquote /Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Intermediates.noindex/SDL_ttf.build/Debug-iphoneos/Framework.build/SDL2_ttf-project-headers.hmap -I/Users/user-name/src/users/SDL_ttf/external/freetype/include -I/Users/user-name/src/users/SDL_ttf/external/harfbuzz -I/Users/user-name/src/users/SDL_ttf/external/harfbuzz/src -I/Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Products/Debug-iphoneos/include -I/Users/user-name/src/users/SDL_ttf/Xcode/iOS/SDL2.framework/Headers -I/Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Intermediates.noindex/SDL_ttf.build/Debug-iphoneos/Framework.build/DerivedSources-normal/arm64 -I/Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Intermediates.noindex/SDL_ttf.build/Debug-iphoneos/Framework.build/DerivedSources/arm64 -I/Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Intermediates.noindex/SDL_ttf.build/Debug-iphoneos/Framework.build/DerivedSources -F/Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Products/Debug-iphoneos -F/Users/user-name/src/users/SDL_ttf/Xcode/iOS -MMD -MT dependencies -MF /Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Intermediates.noindex/SDL_ttf.build/Debug-iphoneos/Framework.build/Objects-normal/arm64/hb-ms-feature-ranges.d --serialize-diagnostics /Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Intermediates.noindex/SDL_ttf.build/Debug-iphoneos/Framework.build/Objects-normal/arm64/hb-ms-feature-ranges.dia -c /Users/user-name/src/users/SDL_ttf/external/harfbuzz/src/hb-ms-feature-ranges.cc -o /Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Intermediates.noindex/SDL_ttf.build/Debug-iphoneos/Framework.build/Objects-normal/arm64/hb-ms-feature-ranges.o -index-unit-output-path /SDL_ttf.build/Debug-iphoneos/Framework.build/Objects-normal/arm64/hb-ms-feature-ranges.o

error: Build input file cannot be found: '/Users/user-name/src/users/SDL_ttf/external/harfbuzz/src/hb-ms-feature-ranges.cc'. Did you forget to declare this file as an output of a script phase or custom build rule which produces it? (in target 'Framework' from project 'SDL_ttf')

Build input file cannot be found: '/Users/user-name/src/users/SDL_ttf/external/harfbuzz/src/hb-ms-feature-ranges.cc'. Did you forget to declare this file as an output of a script phase or custom build rule which produces it?

CompileC /Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Intermediates.noindex/SDL_ttf.build/Debug-iphoneos/Framework.build/Objects-normal/arm64/hb-ot-shape-complex-thai.o /Users/user-name/src/users/SDL_ttf/external/harfbuzz/src/hb-ot-shape-complex-thai.cc normal arm64 c++ com.apple.compilers.llvm.clang.1_0.compiler (in target 'Framework' from project 'SDL_ttf')
    cd /Users/user-name/src/users/SDL_ttf/Xcode
    /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang -x c++ -ivfsstatcache /Users/user-name/Library/Developer/Xcode/DerivedData/SDKStatCaches.noindex/iphoneos17.0-21A326-1e1d10ddc0bdcd738a98873f48b793a5.sdkstatcache -target arm64-apple-ios9.0 -fmessage-length\=0 -fdiagnostics-show-note-include-stack -fmacro-backtrace-limit\=0 -fno-color-diagnostics -std\=c++11 -stdlib\=libc++ -Wno-trigraphs -fpascal-strings -O0 -Wno-missing-field-initializers -Wno-missing-prototypes -Wno-return-type -Wno-non-virtual-dtor -Wno-overloaded-virtual -Wno-exit-time-destructors -Wno-missing-braces -Wparentheses -Wswitch -Wno-unused-function -Wno-unused-label -Wno-unused-parameter -Wno-unused-variable -Wunused-value -Wno-empty-body -Wno-uninitialized -Wno-unknown-pragmas -Wno-shadow -Wno-four-char-constants -Wno-conversion -Wno-constant-conversion -Wno-int-conversion -Wno-bool-conversion -Wno-enum-conversion -Wno-float-conversion -Wno-non-literal-null-conversion -Wno-objc-literal-conversion -Wshorten-64-to-32 -Wno-newline-eof -Wno-c++11-extensions -Wno-implicit-fallthrough -DFT2_BUILD_LIBRARY -DFT_PUBLIC_FUNCTION_ATTRIBUTE\= -DFT_CONFIG_OPTION_USE_HARFBUZZ -DHAVE_CONFIG_H -DTTF_USE_HARFBUZZ\=1 -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS17.0.sdk -fstrict-aliasing -Wdeprecated-declarations -Winvalid-offsetof -g -fvisibility-inlines-hidden -Wno-sign-conversion -Wno-infinite-recursion -Wno-move -Wno-comma -Wno-block-capture-autoreleasing -Wno-strict-prototypes -Wno-range-loop-analysis -Wno-semicolon-before-method-body -index-store-path /Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Index.noindex/DataStore -iquote /Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Intermediates.noindex/SDL_ttf.build/Debug-iphoneos/Framework.build/SDL2_ttf-generated-files.hmap -I/Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Intermediates.noindex/SDL_ttf.build/Debug-iphoneos/Framework.build/SDL2_ttf-own-target-headers.hmap -I/Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Intermediates.noindex/SDL_ttf.build/Debug-iphoneos/Framework.build/SDL2_ttf-all-target-headers.hmap -iquote /Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Intermediates.noindex/SDL_ttf.build/Debug-iphoneos/Framework.build/SDL2_ttf-project-headers.hmap -I/Users/user-name/src/users/SDL_ttf/external/freetype/include -I/Users/user-name/src/users/SDL_ttf/external/harfbuzz -I/Users/user-name/src/users/SDL_ttf/external/harfbuzz/src -I/Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Products/Debug-iphoneos/include -I/Users/user-name/src/users/SDL_ttf/Xcode/iOS/SDL2.framework/Headers -I/Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Intermediates.noindex/SDL_ttf.build/Debug-iphoneos/Framework.build/DerivedSources-normal/arm64 -I/Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Intermediates.noindex/SDL_ttf.build/Debug-iphoneos/Framework.build/DerivedSources/arm64 -I/Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Intermediates.noindex/SDL_ttf.build/Debug-iphoneos/Framework.build/DerivedSources -F/Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Products/Debug-iphoneos -F/Users/user-name/src/users/SDL_ttf/Xcode/iOS -MMD -MT dependencies -MF /Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Intermediates.noindex/SDL_ttf.build/Debug-iphoneos/Framework.build/Objects-normal/arm64/hb-ot-shape-complex-thai.d --serialize-diagnostics /Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Intermediates.noindex/SDL_ttf.build/Debug-iphoneos/Framework.build/Objects-normal/arm64/hb-ot-shape-complex-thai.dia -c /Users/user-name/src/users/SDL_ttf/external/harfbuzz/src/hb-ot-shape-complex-thai.cc -o /Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Intermediates.noindex/SDL_ttf.build/Debug-iphoneos/Framework.build/Objects-normal/arm64/hb-ot-shape-complex-thai.o -index-unit-output-path /SDL_ttf.build/Debug-iphoneos/Framework.build/Objects-normal/arm64/hb-ot-shape-complex-thai.o

error: Build input file cannot be found: '/Users/user-name/src/users/SDL_ttf/external/harfbuzz/src/hb-ot-shape-complex-thai.cc'. Did you forget to declare this file as an output of a script phase or custom build rule which produces it? (in target 'Framework' from project 'SDL_ttf')

Build input file cannot be found: '/Users/user-name/src/users/SDL_ttf/external/harfbuzz/src/hb-ot-shape-complex-thai.cc'. Did you forget to declare this file as an output of a script phase or custom build rule which produces it?

CompileC /Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Intermediates.noindex/SDL_ttf.build/Debug-iphoneos/Framework.build/Objects-normal/arm64/hb-ot-shape-complex-hangul.o /Users/user-name/src/users/SDL_ttf/external/harfbuzz/src/hb-ot-shape-complex-hangul.cc normal arm64 c++ com.apple.compilers.llvm.clang.1_0.compiler (in target 'Framework' from project 'SDL_ttf')
    cd /Users/user-name/src/users/SDL_ttf/Xcode
    /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang -x c++ -ivfsstatcache /Users/user-name/Library/Developer/Xcode/DerivedData/SDKStatCaches.noindex/iphoneos17.0-21A326-1e1d10ddc0bdcd738a98873f48b793a5.sdkstatcache -target arm64-apple-ios9.0 -fmessage-length\=0 -fdiagnostics-show-note-include-stack -fmacro-backtrace-limit\=0 -fno-color-diagnostics -std\=c++11 -stdlib\=libc++ -Wno-trigraphs -fpascal-strings -O0 -Wno-missing-field-initializers -Wno-missing-prototypes -Wno-return-type -Wno-non-virtual-dtor -Wno-overloaded-virtual -Wno-exit-time-destructors -Wno-missing-braces -Wparentheses -Wswitch -Wno-unused-function -Wno-unused-label -Wno-unused-parameter -Wno-unused-variable -Wunused-value -Wno-empty-body -Wno-uninitialized -Wno-unknown-pragmas -Wno-shadow -Wno-four-char-constants -Wno-conversion -Wno-constant-conversion -Wno-int-conversion -Wno-bool-conversion -Wno-enum-conversion -Wno-float-conversion -Wno-non-literal-null-conversion -Wno-objc-literal-conversion -Wshorten-64-to-32 -Wno-newline-eof -Wno-c++11-extensions -Wno-implicit-fallthrough -DFT2_BUILD_LIBRARY -DFT_PUBLIC_FUNCTION_ATTRIBUTE\= -DFT_CONFIG_OPTION_USE_HARFBUZZ -DHAVE_CONFIG_H -DTTF_USE_HARFBUZZ\=1 -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS17.0.sdk -fstrict-aliasing -Wdeprecated-declarations -Winvalid-offsetof -g -fvisibility-inlines-hidden -Wno-sign-conversion -Wno-infinite-recursion -Wno-move -Wno-comma -Wno-block-capture-autoreleasing -Wno-strict-prototypes -Wno-range-loop-analysis -Wno-semicolon-before-method-body -index-store-path /Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Index.noindex/DataStore -iquote /Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Intermediates.noindex/SDL_ttf.build/Debug-iphoneos/Framework.build/SDL2_ttf-generated-files.hmap -I/Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Intermediates.noindex/SDL_ttf.build/Debug-iphoneos/Framework.build/SDL2_ttf-own-target-headers.hmap -I/Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Intermediates.noindex/SDL_ttf.build/Debug-iphoneos/Framework.build/SDL2_ttf-all-target-headers.hmap -iquote /Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Intermediates.noindex/SDL_ttf.build/Debug-iphoneos/Framework.build/SDL2_ttf-project-headers.hmap -I/Users/user-name/src/users/SDL_ttf/external/freetype/include -I/Users/user-name/src/users/SDL_ttf/external/harfbuzz -I/Users/user-name/src/users/SDL_ttf/external/harfbuzz/src -I/Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Products/Debug-iphoneos/include -I/Users/user-name/src/users/SDL_ttf/Xcode/iOS/SDL2.framework/Headers -I/Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Intermediates.noindex/SDL_ttf.build/Debug-iphoneos/Framework.build/DerivedSources-normal/arm64 -I/Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Intermediates.noindex/SDL_ttf.build/Debug-iphoneos/Framework.build/DerivedSources/arm64 -I/Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Intermediates.noindex/SDL_ttf.build/Debug-iphoneos/Framework.build/DerivedSources -F/Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Products/Debug-iphoneos -F/Users/user-name/src/users/SDL_ttf/Xcode/iOS -MMD -MT dependencies -MF /Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Intermediates.noindex/SDL_ttf.build/Debug-iphoneos/Framework.build/Objects-normal/arm64/hb-ot-shape-complex-hangul.d --serialize-diagnostics /Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Intermediates.noindex/SDL_ttf.build/Debug-iphoneos/Framework.build/Objects-normal/arm64/hb-ot-shape-complex-hangul.dia -c /Users/user-name/src/users/SDL_ttf/external/harfbuzz/src/hb-ot-shape-complex-hangul.cc -o /Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Intermediates.noindex/SDL_ttf.build/Debug-iphoneos/Framework.build/Objects-normal/arm64/hb-ot-shape-complex-hangul.o -index-unit-output-path /SDL_ttf.build/Debug-iphoneos/Framework.build/Objects-normal/arm64/hb-ot-shape-complex-hangul.o

error: Build input file cannot be found: '/Users/user-name/src/users/SDL_ttf/external/harfbuzz/src/hb-ot-shape-complex-hangul.cc'. Did you forget to declare this file as an output of a script phase or custom build rule which produces it? (in target 'Framework' from project 'SDL_ttf')

Build input file cannot be found: '/Users/user-name/src/users/SDL_ttf/external/harfbuzz/src/hb-ot-shape-complex-hangul.cc'. Did you forget to declare this file as an output of a script phase or custom build rule which produces it?

CompileC /Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Intermediates.noindex/SDL_ttf.build/Debug-iphoneos/Framework.build/Objects-normal/arm64/hb-ot-shape-complex-indic-table.o /Users/user-name/src/users/SDL_ttf/external/harfbuzz/src/hb-ot-shape-complex-indic-table.cc normal arm64 c++ com.apple.compilers.llvm.clang.1_0.compiler (in target 'Framework' from project 'SDL_ttf')
    cd /Users/user-name/src/users/SDL_ttf/Xcode
    /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang -x c++ -ivfsstatcache /Users/user-name/Library/Developer/Xcode/DerivedData/SDKStatCaches.noindex/iphoneos17.0-21A326-1e1d10ddc0bdcd738a98873f48b793a5.sdkstatcache -target arm64-apple-ios9.0 -fmessage-length\=0 -fdiagnostics-show-note-include-stack -fmacro-backtrace-limit\=0 -fno-color-diagnostics -std\=c++11 -stdlib\=libc++ -Wno-trigraphs -fpascal-strings -O0 -Wno-missing-field-initializers -Wno-missing-prototypes -Wno-return-type -Wno-non-virtual-dtor -Wno-overloaded-virtual -Wno-exit-time-destructors -Wno-missing-braces -Wparentheses -Wswitch -Wno-unused-function -Wno-unused-label -Wno-unused-parameter -Wno-unused-variable -Wunused-value -Wno-empty-body -Wno-uninitialized -Wno-unknown-pragmas -Wno-shadow -Wno-four-char-constants -Wno-conversion -Wno-constant-conversion -Wno-int-conversion -Wno-bool-conversion -Wno-enum-conversion -Wno-float-conversion -Wno-non-literal-null-conversion -Wno-objc-literal-conversion -Wshorten-64-to-32 -Wno-newline-eof -Wno-c++11-extensions -Wno-implicit-fallthrough -DFT2_BUILD_LIBRARY -DFT_PUBLIC_FUNCTION_ATTRIBUTE\= -DFT_CONFIG_OPTION_USE_HARFBUZZ -DHAVE_CONFIG_H -DTTF_USE_HARFBUZZ\=1 -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS17.0.sdk -fstrict-aliasing -Wdeprecated-declarations -Winvalid-offsetof -g -fvisibility-inlines-hidden -Wno-sign-conversion -Wno-infinite-recursion -Wno-move -Wno-comma -Wno-block-capture-autoreleasing -Wno-strict-prototypes -Wno-range-loop-analysis -Wno-semicolon-before-method-body -index-store-path /Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Index.noindex/DataStore -iquote /Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Intermediates.noindex/SDL_ttf.build/Debug-iphoneos/Framework.build/SDL2_ttf-generated-files.hmap -I/Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Intermediates.noindex/SDL_ttf.build/Debug-iphoneos/Framework.build/SDL2_ttf-own-target-headers.hmap -I/Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Intermediates.noindex/SDL_ttf.build/Debug-iphoneos/Framework.build/SDL2_ttf-all-target-headers.hmap -iquote /Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Intermediates.noindex/SDL_ttf.build/Debug-iphoneos/Framework.build/SDL2_ttf-project-headers.hmap -I/Users/user-name/src/users/SDL_ttf/external/freetype/include -I/Users/user-name/src/users/SDL_ttf/external/harfbuzz -I/Users/user-name/src/users/SDL_ttf/external/harfbuzz/src -I/Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Products/Debug-iphoneos/include -I/Users/user-name/src/users/SDL_ttf/Xcode/iOS/SDL2.framework/Headers -I/Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Intermediates.noindex/SDL_ttf.build/Debug-iphoneos/Framework.build/DerivedSources-normal/arm64 -I/Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Intermediates.noindex/SDL_ttf.build/Debug-iphoneos/Framework.build/DerivedSources/arm64 -I/Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Intermediates.noindex/SDL_ttf.build/Debug-iphoneos/Framework.build/DerivedSources -F/Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Products/Debug-iphoneos -F/Users/user-name/src/users/SDL_ttf/Xcode/iOS -MMD -MT dependencies -MF /Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Intermediates.noindex/SDL_ttf.build/Debug-iphoneos/Framework.build/Objects-normal/arm64/hb-ot-shape-complex-indic-table.d --serialize-diagnostics /Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Intermediates.noindex/SDL_ttf.build/Debug-iphoneos/Framework.build/Objects-normal/arm64/hb-ot-shape-complex-indic-table.dia -c /Users/user-name/src/users/SDL_ttf/external/harfbuzz/src/hb-ot-shape-complex-indic-table.cc -o /Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Intermediates.noindex/SDL_ttf.build/Debug-iphoneos/Framework.build/Objects-normal/arm64/hb-ot-shape-complex-indic-table.o -index-unit-output-path /SDL_ttf.build/Debug-iphoneos/Framework.build/Objects-normal/arm64/hb-ot-shape-complex-indic-table.o

error: Build input file cannot be found: '/Users/user-name/src/users/SDL_ttf/external/harfbuzz/src/hb-ot-shape-complex-indic-table.cc'. Did you forget to declare this file as an output of a script phase or custom build rule which produces it? (in target 'Framework' from project 'SDL_ttf')

Build input file cannot be found: '/Users/user-name/src/users/SDL_ttf/external/harfbuzz/src/hb-ot-shape-complex-indic-table.cc'. Did you forget to declare this file as an output of a script phase or custom build rule which produces it?

CompileC /Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Intermediates.noindex/SDL_ttf.build/Debug-iphoneos/Framework.build/Objects-normal/arm64/hb-ot-shape-complex-use.o /Users/user-name/src/users/SDL_ttf/external/harfbuzz/src/hb-ot-shape-complex-use.cc normal arm64 c++ com.apple.compilers.llvm.clang.1_0.compiler (in target 'Framework' from project 'SDL_ttf')
    cd /Users/user-name/src/users/SDL_ttf/Xcode
    /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang -x c++ -ivfsstatcache /Users/user-name/Library/Developer/Xcode/DerivedData/SDKStatCaches.noindex/iphoneos17.0-21A326-1e1d10ddc0bdcd738a98873f48b793a5.sdkstatcache -target arm64-apple-ios9.0 -fmessage-length\=0 -fdiagnostics-show-note-include-stack -fmacro-backtrace-limit\=0 -fno-color-diagnostics -std\=c++11 -stdlib\=libc++ -Wno-trigraphs -fpascal-strings -O0 -Wno-missing-field-initializers -Wno-missing-prototypes -Wno-return-type -Wno-non-virtual-dtor -Wno-overloaded-virtual -Wno-exit-time-destructors -Wno-missing-braces -Wparentheses -Wswitch -Wno-unused-function -Wno-unused-label -Wno-unused-parameter -Wno-unused-variable -Wunused-value -Wno-empty-body -Wno-uninitialized -Wno-unknown-pragmas -Wno-shadow -Wno-four-char-constants -Wno-conversion -Wno-constant-conversion -Wno-int-conversion -Wno-bool-conversion -Wno-enum-conversion -Wno-float-conversion -Wno-non-literal-null-conversion -Wno-objc-literal-conversion -Wshorten-64-to-32 -Wno-newline-eof -Wno-c++11-extensions -Wno-implicit-fallthrough -DFT2_BUILD_LIBRARY -DFT_PUBLIC_FUNCTION_ATTRIBUTE\= -DFT_CONFIG_OPTION_USE_HARFBUZZ -DHAVE_CONFIG_H -DTTF_USE_HARFBUZZ\=1 -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS17.0.sdk -fstrict-aliasing -Wdeprecated-declarations -Winvalid-offsetof -g -fvisibility-inlines-hidden -Wno-sign-conversion -Wno-infinite-recursion -Wno-move -Wno-comma -Wno-block-capture-autoreleasing -Wno-strict-prototypes -Wno-range-loop-analysis -Wno-semicolon-before-method-body -index-store-path /Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Index.noindex/DataStore -iquote /Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Intermediates.noindex/SDL_ttf.build/Debug-iphoneos/Framework.build/SDL2_ttf-generated-files.hmap -I/Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Intermediates.noindex/SDL_ttf.build/Debug-iphoneos/Framework.build/SDL2_ttf-own-target-headers.hmap -I/Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Intermediates.noindex/SDL_ttf.build/Debug-iphoneos/Framework.build/SDL2_ttf-all-target-headers.hmap -iquote /Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Intermediates.noindex/SDL_ttf.build/Debug-iphoneos/Framework.build/SDL2_ttf-project-headers.hmap -I/Users/user-name/src/users/SDL_ttf/external/freetype/include -I/Users/user-name/src/users/SDL_ttf/external/harfbuzz -I/Users/user-name/src/users/SDL_ttf/external/harfbuzz/src -I/Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Products/Debug-iphoneos/include -I/Users/user-name/src/users/SDL_ttf/Xcode/iOS/SDL2.framework/Headers -I/Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Intermediates.noindex/SDL_ttf.build/Debug-iphoneos/Framework.build/DerivedSources-normal/arm64 -I/Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Intermediates.noindex/SDL_ttf.build/Debug-iphoneos/Framework.build/DerivedSources/arm64 -I/Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Intermediates.noindex/SDL_ttf.build/Debug-iphoneos/Framework.build/DerivedSources -F/Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Products/Debug-iphoneos -F/Users/user-name/src/users/SDL_ttf/Xcode/iOS -MMD -MT dependencies -MF /Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Intermediates.noindex/SDL_ttf.build/Debug-iphoneos/Framework.build/Objects-normal/arm64/hb-ot-shape-complex-use.d --serialize-diagnostics /Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Intermediates.noindex/SDL_ttf.build/Debug-iphoneos/Framework.build/Objects-normal/arm64/hb-ot-shape-complex-use.dia -c /Users/user-name/src/users/SDL_ttf/external/harfbuzz/src/hb-ot-shape-complex-use.cc -o /Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Intermediates.noindex/SDL_ttf.build/Debug-iphoneos/Framework.build/Objects-normal/arm64/hb-ot-shape-complex-use.o -index-unit-output-path /SDL_ttf.build/Debug-iphoneos/Framework.build/Objects-normal/arm64/hb-ot-shape-complex-use.o

error: Build input file cannot be found: '/Users/user-name/src/users/SDL_ttf/external/harfbuzz/src/hb-ot-shape-complex-use.cc'. Did you forget to declare this file as an output of a script phase or custom build rule which produces it? (in target 'Framework' from project 'SDL_ttf')

Build input file cannot be found: '/Users/user-name/src/users/SDL_ttf/external/harfbuzz/src/hb-ot-shape-complex-use.cc'. Did you forget to declare this file as an output of a script phase or custom build rule which produces it?

CompileC /Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Intermediates.noindex/SDL_ttf.build/Debug-iphoneos/Framework.build/Objects-normal/arm64/hb-ot-shape-complex-myanmar.o /Users/user-name/src/users/SDL_ttf/external/harfbuzz/src/hb-ot-shape-complex-myanmar.cc normal arm64 c++ com.apple.compilers.llvm.clang.1_0.compiler (in target 'Framework' from project 'SDL_ttf')
    cd /Users/user-name/src/users/SDL_ttf/Xcode
    /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang -x c++ -ivfsstatcache /Users/user-name/Library/Developer/Xcode/DerivedData/SDKStatCaches.noindex/iphoneos17.0-21A326-1e1d10ddc0bdcd738a98873f48b793a5.sdkstatcache -target arm64-apple-ios9.0 -fmessage-length\=0 -fdiagnostics-show-note-include-stack -fmacro-backtrace-limit\=0 -fno-color-diagnostics -std\=c++11 -stdlib\=libc++ -Wno-trigraphs -fpascal-strings -O0 -Wno-missing-field-initializers -Wno-missing-prototypes -Wno-return-type -Wno-non-virtual-dtor -Wno-overloaded-virtual -Wno-exit-time-destructors -Wno-missing-braces -Wparentheses -Wswitch -Wno-unused-function -Wno-unused-label -Wno-unused-parameter -Wno-unused-variable -Wunused-value -Wno-empty-body -Wno-uninitialized -Wno-unknown-pragmas -Wno-shadow -Wno-four-char-constants -Wno-conversion -Wno-constant-conversion -Wno-int-conversion -Wno-bool-conversion -Wno-enum-conversion -Wno-float-conversion -Wno-non-literal-null-conversion -Wno-objc-literal-conversion -Wshorten-64-to-32 -Wno-newline-eof -Wno-c++11-extensions -Wno-implicit-fallthrough -DFT2_BUILD_LIBRARY -DFT_PUBLIC_FUNCTION_ATTRIBUTE\= -DFT_CONFIG_OPTION_USE_HARFBUZZ -DHAVE_CONFIG_H -DTTF_USE_HARFBUZZ\=1 -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS17.0.sdk -fstrict-aliasing -Wdeprecated-declarations -Winvalid-offsetof -g -fvisibility-inlines-hidden -Wno-sign-conversion -Wno-infinite-recursion -Wno-move -Wno-comma -Wno-block-capture-autoreleasing -Wno-strict-prototypes -Wno-range-loop-analysis -Wno-semicolon-before-method-body -index-store-path /Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Index.noindex/DataStore -iquote /Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Intermediates.noindex/SDL_ttf.build/Debug-iphoneos/Framework.build/SDL2_ttf-generated-files.hmap -I/Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Intermediates.noindex/SDL_ttf.build/Debug-iphoneos/Framework.build/SDL2_ttf-own-target-headers.hmap -I/Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Intermediates.noindex/SDL_ttf.build/Debug-iphoneos/Framework.build/SDL2_ttf-all-target-headers.hmap -iquote /Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Intermediates.noindex/SDL_ttf.build/Debug-iphoneos/Framework.build/SDL2_ttf-project-headers.hmap -I/Users/user-name/src/users/SDL_ttf/external/freetype/include -I/Users/user-name/src/users/SDL_ttf/external/harfbuzz -I/Users/user-name/src/users/SDL_ttf/external/harfbuzz/src -I/Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Products/Debug-iphoneos/include -I/Users/user-name/src/users/SDL_ttf/Xcode/iOS/SDL2.framework/Headers -I/Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Intermediates.noindex/SDL_ttf.build/Debug-iphoneos/Framework.build/DerivedSources-normal/arm64 -I/Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Intermediates.noindex/SDL_ttf.build/Debug-iphoneos/Framework.build/DerivedSources/arm64 -I/Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Intermediates.noindex/SDL_ttf.build/Debug-iphoneos/Framework.build/DerivedSources -F/Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Products/Debug-iphoneos -F/Users/user-name/src/users/SDL_ttf/Xcode/iOS -MMD -MT dependencies -MF /Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Intermediates.noindex/SDL_ttf.build/Debug-iphoneos/Framework.build/Objects-normal/arm64/hb-ot-shape-complex-myanmar.d --serialize-diagnostics /Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Intermediates.noindex/SDL_ttf.build/Debug-iphoneos/Framework.build/Objects-normal/arm64/hb-ot-shape-complex-myanmar.dia -c /Users/user-name/src/users/SDL_ttf/external/harfbuzz/src/hb-ot-shape-complex-myanmar.cc -o /Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Intermediates.noindex/SDL_ttf.build/Debug-iphoneos/Framework.build/Objects-normal/arm64/hb-ot-shape-complex-myanmar.o -index-unit-output-path /SDL_ttf.build/Debug-iphoneos/Framework.build/Objects-normal/arm64/hb-ot-shape-complex-myanmar.o

error: Build input file cannot be found: '/Users/user-name/src/users/SDL_ttf/external/harfbuzz/src/hb-ot-shape-complex-myanmar.cc'. Did you forget to declare this file as an output of a script phase or custom build rule which produces it? (in target 'Framework' from project 'SDL_ttf')

Build input file cannot be found: '/Users/user-name/src/users/SDL_ttf/external/harfbuzz/src/hb-ot-shape-complex-myanmar.cc'. Did you forget to declare this file as an output of a script phase or custom build rule which produces it?

CompileC /Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Intermediates.noindex/SDL_ttf.build/Debug-iphoneos/Framework.build/Objects-normal/arm64/hb-ot-shape-complex-syllabic.o /Users/user-name/src/users/SDL_ttf/external/harfbuzz/src/hb-ot-shape-complex-syllabic.cc normal arm64 c++ com.apple.compilers.llvm.clang.1_0.compiler (in target 'Framework' from project 'SDL_ttf')
    cd /Users/user-name/src/users/SDL_ttf/Xcode
    /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang -x c++ -ivfsstatcache /Users/user-name/Library/Developer/Xcode/DerivedData/SDKStatCaches.noindex/iphoneos17.0-21A326-1e1d10ddc0bdcd738a98873f48b793a5.sdkstatcache -target arm64-apple-ios9.0 -fmessage-length\=0 -fdiagnostics-show-note-include-stack -fmacro-backtrace-limit\=0 -fno-color-diagnostics -std\=c++11 -stdlib\=libc++ -Wno-trigraphs -fpascal-strings -O0 -Wno-missing-field-initializers -Wno-missing-prototypes -Wno-return-type -Wno-non-virtual-dtor -Wno-overloaded-virtual -Wno-exit-time-destructors -Wno-missing-braces -Wparentheses -Wswitch -Wno-unused-function -Wno-unused-label -Wno-unused-parameter -Wno-unused-variable -Wunused-value -Wno-empty-body -Wno-uninitialized -Wno-unknown-pragmas -Wno-shadow -Wno-four-char-constants -Wno-conversion -Wno-constant-conversion -Wno-int-conversion -Wno-bool-conversion -Wno-enum-conversion -Wno-float-conversion -Wno-non-literal-null-conversion -Wno-objc-literal-conversion -Wshorten-64-to-32 -Wno-newline-eof -Wno-c++11-extensions -Wno-implicit-fallthrough -DFT2_BUILD_LIBRARY -DFT_PUBLIC_FUNCTION_ATTRIBUTE\= -DFT_CONFIG_OPTION_USE_HARFBUZZ -DHAVE_CONFIG_H -DTTF_USE_HARFBUZZ\=1 -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS17.0.sdk -fstrict-aliasing -Wdeprecated-declarations -Winvalid-offsetof -g -fvisibility-inlines-hidden -Wno-sign-conversion -Wno-infinite-recursion -Wno-move -Wno-comma -Wno-block-capture-autoreleasing -Wno-strict-prototypes -Wno-range-loop-analysis -Wno-semicolon-before-method-body -index-store-path /Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Index.noindex/DataStore -iquote /Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Intermediates.noindex/SDL_ttf.build/Debug-iphoneos/Framework.build/SDL2_ttf-generated-files.hmap -I/Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Intermediates.noindex/SDL_ttf.build/Debug-iphoneos/Framework.build/SDL2_ttf-own-target-headers.hmap -I/Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Intermediates.noindex/SDL_ttf.build/Debug-iphoneos/Framework.build/SDL2_ttf-all-target-headers.hmap -iquote /Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Intermediates.noindex/SDL_ttf.build/Debug-iphoneos/Framework.build/SDL2_ttf-project-headers.hmap -I/Users/user-name/src/users/SDL_ttf/external/freetype/include -I/Users/user-name/src/users/SDL_ttf/external/harfbuzz -I/Users/user-name/src/users/SDL_ttf/external/harfbuzz/src -I/Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Products/Debug-iphoneos/include -I/Users/user-name/src/users/SDL_ttf/Xcode/iOS/SDL2.framework/Headers -I/Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Intermediates.noindex/SDL_ttf.build/Debug-iphoneos/Framework.build/DerivedSources-normal/arm64 -I/Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Intermediates.noindex/SDL_ttf.build/Debug-iphoneos/Framework.build/DerivedSources/arm64 -I/Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Intermediates.noindex/SDL_ttf.build/Debug-iphoneos/Framework.build/DerivedSources -F/Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Products/Debug-iphoneos -F/Users/user-name/src/users/SDL_ttf/Xcode/iOS -MMD -MT dependencies -MF /Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Intermediates.noindex/SDL_ttf.build/Debug-iphoneos/Framework.build/Objects-normal/arm64/hb-ot-shape-complex-syllabic.d --serialize-diagnostics /Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Intermediates.noindex/SDL_ttf.build/Debug-iphoneos/Framework.build/Objects-normal/arm64/hb-ot-shape-complex-syllabic.dia -c /Users/user-name/src/users/SDL_ttf/external/harfbuzz/src/hb-ot-shape-complex-syllabic.cc -o /Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Intermediates.noindex/SDL_ttf.build/Debug-iphoneos/Framework.build/Objects-normal/arm64/hb-ot-shape-complex-syllabic.o -index-unit-output-path /SDL_ttf.build/Debug-iphoneos/Framework.build/Objects-normal/arm64/hb-ot-shape-complex-syllabic.o

error: Build input file cannot be found: '/Users/user-name/src/users/SDL_ttf/external/harfbuzz/src/hb-ot-shape-complex-syllabic.cc'. Did you forget to declare this file as an output of a script phase or custom build rule which produces it? (in target 'Framework' from project 'SDL_ttf')

Build input file cannot be found: '/Users/user-name/src/users/SDL_ttf/external/harfbuzz/src/hb-ot-shape-complex-syllabic.cc'. Did you forget to declare this file as an output of a script phase or custom build rule which produces it?

CompileC /Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Intermediates.noindex/SDL_ttf.build/Debug-iphoneos/Framework.build/Objects-normal/arm64/hb-ot-shape-complex-vowel-constraints.o /Users/user-name/src/users/SDL_ttf/external/harfbuzz/src/hb-ot-shape-complex-vowel-constraints.cc normal arm64 c++ com.apple.compilers.llvm.clang.1_0.compiler (in target 'Framework' from project 'SDL_ttf')
    cd /Users/user-name/src/users/SDL_ttf/Xcode
    /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang -x c++ -ivfsstatcache /Users/user-name/Library/Developer/Xcode/DerivedData/SDKStatCaches.noindex/iphoneos17.0-21A326-1e1d10ddc0bdcd738a98873f48b793a5.sdkstatcache -target arm64-apple-ios9.0 -fmessage-length\=0 -fdiagnostics-show-note-include-stack -fmacro-backtrace-limit\=0 -fno-color-diagnostics -std\=c++11 -stdlib\=libc++ -Wno-trigraphs -fpascal-strings -O0 -Wno-missing-field-initializers -Wno-missing-prototypes -Wno-return-type -Wno-non-virtual-dtor -Wno-overloaded-virtual -Wno-exit-time-destructors -Wno-missing-braces -Wparentheses -Wswitch -Wno-unused-function -Wno-unused-label -Wno-unused-parameter -Wno-unused-variable -Wunused-value -Wno-empty-body -Wno-uninitialized -Wno-unknown-pragmas -Wno-shadow -Wno-four-char-constants -Wno-conversion -Wno-constant-conversion -Wno-int-conversion -Wno-bool-conversion -Wno-enum-conversion -Wno-float-conversion -Wno-non-literal-null-conversion -Wno-objc-literal-conversion -Wshorten-64-to-32 -Wno-newline-eof -Wno-c++11-extensions -Wno-implicit-fallthrough -DFT2_BUILD_LIBRARY -DFT_PUBLIC_FUNCTION_ATTRIBUTE\= -DFT_CONFIG_OPTION_USE_HARFBUZZ -DHAVE_CONFIG_H -DTTF_USE_HARFBUZZ\=1 -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS17.0.sdk -fstrict-aliasing -Wdeprecated-declarations -Winvalid-offsetof -g -fvisibility-inlines-hidden -Wno-sign-conversion -Wno-infinite-recursion -Wno-move -Wno-comma -Wno-block-capture-autoreleasing -Wno-strict-prototypes -Wno-range-loop-analysis -Wno-semicolon-before-method-body -index-store-path /Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Index.noindex/DataStore -iquote /Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Intermediates.noindex/SDL_ttf.build/Debug-iphoneos/Framework.build/SDL2_ttf-generated-files.hmap -I/Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Intermediates.noindex/SDL_ttf.build/Debug-iphoneos/Framework.build/SDL2_ttf-own-target-headers.hmap -I/Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Intermediates.noindex/SDL_ttf.build/Debug-iphoneos/Framework.build/SDL2_ttf-all-target-headers.hmap -iquote /Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Intermediates.noindex/SDL_ttf.build/Debug-iphoneos/Framework.build/SDL2_ttf-project-headers.hmap -I/Users/user-name/src/users/SDL_ttf/external/freetype/include -I/Users/user-name/src/users/SDL_ttf/external/harfbuzz -I/Users/user-name/src/users/SDL_ttf/external/harfbuzz/src -I/Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Products/Debug-iphoneos/include -I/Users/user-name/src/users/SDL_ttf/Xcode/iOS/SDL2.framework/Headers -I/Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Intermediates.noindex/SDL_ttf.build/Debug-iphoneos/Framework.build/DerivedSources-normal/arm64 -I/Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Intermediates.noindex/SDL_ttf.build/Debug-iphoneos/Framework.build/DerivedSources/arm64 -I/Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Intermediates.noindex/SDL_ttf.build/Debug-iphoneos/Framework.build/DerivedSources -F/Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Products/Debug-iphoneos -F/Users/user-name/src/users/SDL_ttf/Xcode/iOS -MMD -MT dependencies -MF /Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Intermediates.noindex/SDL_ttf.build/Debug-iphoneos/Framework.build/Objects-normal/arm64/hb-ot-shape-complex-vowel-constraints.d --serialize-diagnostics /Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Intermediates.noindex/SDL_ttf.build/Debug-iphoneos/Framework.build/Objects-normal/arm64/hb-ot-shape-complex-vowel-constraints.dia -c /Users/user-name/src/users/SDL_ttf/external/harfbuzz/src/hb-ot-shape-complex-vowel-constraints.cc -o /Users/user-name/Library/Developer/Xcode/DerivedData/SDL_ttf-ghwlbcshkzfftcbdnzxlssvbrkxl/Build/Intermediates.noindex/SDL_ttf.build/Debug-iphoneos/Framework.build/Objects-normal/arm64/hb-ot-shape-complex-vowel-constraints.o -index-unit-output-path /SDL_ttf.build/Debug-iphoneos/Framework.build/Objects-normal/arm64/hb-ot-shape-complex-vowel-constraints.o

error: Build input file cannot be found: '/Users/user-name/src/users/SDL_ttf/external/harfbuzz/src/hb-ot-shape-complex-vowel-constraints.cc'. Did you forget to declare this file as an output of a script phase or custom build rule which produces it? (in target 'Framework' from project 'SDL_ttf')

Build input file cannot be found: '/Users/user-name/src/users/SDL_ttf/external/harfbuzz/src/hb-ot-shape-complex-vowel-constraints.cc'. Did you forget to declare this file as an output of a script phase or custom build rule which produces it?



Build failed    05.01.24, 18:56    1.0 seconds

  ```
</details>