### PR TITLE
 xcode: fix the list of files from the harfbuzz library.

### DIFF
--- a/Xcode/SDL_ttf.xcodeproj/project.pbxproj
+++ b/Xcode/SDL_ttf.xcodeproj/project.pbxproj
@@ -33,11 +33,34 @@
 /* End PBXAggregateTarget section */
 
 /* Begin PBXBuildFile section */
+		61047EA42B48AD0F00868128 /* hb-ot-shaper-syllabic.cc in Sources */ = {isa = PBXBuildFile; fileRef = 61047E8D2B48AD0D00868128 /* hb-ot-shaper-syllabic.cc */; };
+		61047EA52B48AD0F00868128 /* hb-paint-extents.cc in Sources */ = {isa = PBXBuildFile; fileRef = 61047E8E2B48AD0D00868128 /* hb-paint-extents.cc */; };
+		61047EA62B48AD0F00868128 /* hb-ot-name.cc in Sources */ = {isa = PBXBuildFile; fileRef = 61047E8F2B48AD0D00868128 /* hb-ot-name.cc */; };
+		61047EA72B48AD0F00868128 /* hb-coretext.cc in Sources */ = {isa = PBXBuildFile; fileRef = 61047E902B48AD0D00868128 /* hb-coretext.cc */; };
+		61047EA82B48AD0F00868128 /* hb-paint.cc in Sources */ = {isa = PBXBuildFile; fileRef = 61047E912B48AD0D00868128 /* hb-paint.cc */; };
+		61047EA92B48AD0F00868128 /* hb-face-builder.cc in Sources */ = {isa = PBXBuildFile; fileRef = 61047E922B48AD0E00868128 /* hb-face-builder.cc */; };
+		61047EAA2B48AD0F00868128 /* hb-ot-shaper-arabic.cc in Sources */ = {isa = PBXBuildFile; fileRef = 61047E932B48AD0E00868128 /* hb-ot-shaper-arabic.cc */; };
+		61047EAB2B48AD0F00868128 /* hb-draw.cc in Sources */ = {isa = PBXBuildFile; fileRef = 61047E942B48AD0E00868128 /* hb-draw.cc */; };
+		61047EAC2B48AD0F00868128 /* hb-ot-shaper-indic.cc in Sources */ = {isa = PBXBuildFile; fileRef = 61047E952B48AD0E00868128 /* hb-ot-shaper-indic.cc */; };
+		61047EAD2B48AD0F00868128 /* hb-ot-shaper-indic-table.cc in Sources */ = {isa = PBXBuildFile; fileRef = 61047E962B48AD0E00868128 /* hb-ot-shaper-indic-table.cc */; };
+		61047EAE2B48AD0F00868128 /* hb-style.cc in Sources */ = {isa = PBXBuildFile; fileRef = 61047E972B48AD0E00868128 /* hb-style.cc */; };
+		61047EAF2B48AD0F00868128 /* hb-ot-shaper-use.cc in Sources */ = {isa = PBXBuildFile; fileRef = 61047E982B48AD0E00868128 /* hb-ot-shaper-use.cc */; };
+		61047EB02B48AD0F00868128 /* hb-ot-shaper-khmer.cc in Sources */ = {isa = PBXBuildFile; fileRef = 61047E992B48AD0E00868128 /* hb-ot-shaper-khmer.cc */; };
+		61047EB12B48AD0F00868128 /* hb-ot-shaper-vowel-constraints.cc in Sources */ = {isa = PBXBuildFile; fileRef = 61047E9A2B48AD0E00868128 /* hb-ot-shaper-vowel-constraints.cc */; };
+		61047EB22B48AD0F00868128 /* hb-ot-shaper-hangul.cc in Sources */ = {isa = PBXBuildFile; fileRef = 61047E9B2B48AD0E00868128 /* hb-ot-shaper-hangul.cc */; };
+		61047EB32B48AD0F00868128 /* hb-ot-meta.cc in Sources */ = {isa = PBXBuildFile; fileRef = 61047E9C2B48AD0E00868128 /* hb-ot-meta.cc */; };
+		61047EB42B48AD0F00868128 /* hb-ot-shaper-thai.cc in Sources */ = {isa = PBXBuildFile; fileRef = 61047E9D2B48AD0F00868128 /* hb-ot-shaper-thai.cc */; };
+		61047EB52B48AD0F00868128 /* hb-ot-shaper-hebrew.cc in Sources */ = {isa = PBXBuildFile; fileRef = 61047E9E2B48AD0F00868128 /* hb-ot-shaper-hebrew.cc */; };
+		61047EB62B48AD0F00868128 /* hb-outline.cc in Sources */ = {isa = PBXBuildFile; fileRef = 61047E9F2B48AD0F00868128 /* hb-outline.cc */; };
+		61047EB72B48AD0F00868128 /* hb-ot-shaper-default.cc in Sources */ = {isa = PBXBuildFile; fileRef = 61047EA02B48AD0F00868128 /* hb-ot-shaper-default.cc */; };
+		61047EB82B48AD0F00868128 /* hb-directwrite.cc in Sources */ = {isa = PBXBuildFile; fileRef = 61047EA12B48AD0F00868128 /* hb-directwrite.cc */; };
+		61047EB92B48AD0F00868128 /* hb-ot-shaper-myanmar.cc in Sources */ = {isa = PBXBuildFile; fileRef = 61047EA22B48AD0F00868128 /* hb-ot-shaper-myanmar.cc */; };
+		61047EBA2B48AD0F00868128 /* hb-ot-color.cc in Sources */ = {isa = PBXBuildFile; fileRef = 61047EA32B48AD0F00868128 /* hb-ot-color.cc */; };
+		61047EBC2B48AF9700868128 /* hb-buffer-verify.cc in Sources */ = {isa = PBXBuildFile; fileRef = 61047EBB2B48AF9700868128 /* hb-buffer-verify.cc */; };
 		7FC2F5DC285AC0D600836845 /* CMake in Resources */ = {isa = PBXBuildFile; fileRef = 7FC2F5DB285AC0D600836845 /* CMake */; };
 		BE48FD5F07AFA17000BB41DA /* SDL_ttf.h in Headers */ = {isa = PBXBuildFile; fileRef = 1014BAEA010A4B677F000001 /* SDL_ttf.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BE48FD6207AFA17000BB41DA /* SDL_ttf.c in Sources */ = {isa = PBXBuildFile; fileRef = F567D67A01CD962A01F3E8B9 /* SDL_ttf.c */; };
 		F307EE29282738F8003915D7 /* svg.c in Sources */ = {isa = PBXBuildFile; fileRef = F307EE28282738F8003915D7 /* svg.c */; };
-		F307EE2C282807EB003915D7 /* hb-ms-feature-ranges.cc in Sources */ = {isa = PBXBuildFile; fileRef = F307EE2B282807EB003915D7 /* hb-ms-feature-ranges.cc */; };
 		F364A5B82620E1A200325ECE /* FTL.TXT in Resources */ = {isa = PBXBuildFile; fileRef = F364A5B72620E1A200325ECE /* FTL.TXT */; };
 		F364A5C42620E22400325ECE /* ReadMe.txt in Resources */ = {isa = PBXBuildFile; fileRef = F364A5C32620E22400325ECE /* ReadMe.txt */; };
 		F3696FE4278F7107003A7F94 /* sdf.c in Sources */ = {isa = PBXBuildFile; fileRef = F3696FE3278F7107003A7F94 /* sdf.c */; };
@@ -81,35 +104,24 @@
 		F384BCD4261EC2BE0028A248 /* type42.c in Sources */ = {isa = PBXBuildFile; fileRef = F384BCD3261EC2BE0028A248 /* type42.c */; };
 		F384BCDF261EC2CF0028A248 /* winfnt.c in Sources */ = {isa = PBXBuildFile; fileRef = F384BCDE261EC2CF0028A248 /* winfnt.c */; };
 		F384BCF2261EC5130028A248 /* ftcache.c in Sources */ = {isa = PBXBuildFile; fileRef = F384BCF1261EC5130028A248 /* ftcache.c */; };
-		F384BD2F261EC7650028A248 /* hb-ot-shape-complex-default.cc in Sources */ = {isa = PBXBuildFile; fileRef = F384BD05261EC7640028A248 /* hb-ot-shape-complex-default.cc */; };
 		F384BD35261EC7650028A248 /* hb-set.cc in Sources */ = {isa = PBXBuildFile; fileRef = F384BD06261EC7640028A248 /* hb-set.cc */; };
 		F384BD3B261EC7650028A248 /* hb-shape.cc in Sources */ = {isa = PBXBuildFile; fileRef = F384BD07261EC7640028A248 /* hb-shape.cc */; };
 		F384BD41261EC7650028A248 /* hb-static.cc in Sources */ = {isa = PBXBuildFile; fileRef = F384BD08261EC7640028A248 /* hb-static.cc */; };
-		F384BD47261EC7650028A248 /* hb-ot-shape-complex-hebrew.cc in Sources */ = {isa = PBXBuildFile; fileRef = F384BD09261EC7640028A248 /* hb-ot-shape-complex-hebrew.cc */; };
 		F384BD4D261EC7650028A248 /* hb-ucd.cc in Sources */ = {isa = PBXBuildFile; fileRef = F384BD0A261EC7640028A248 /* hb-ucd.cc */; };
-		F384BD53261EC7650028A248 /* hb-ot-shape-complex-indic-table.cc in Sources */ = {isa = PBXBuildFile; fileRef = F384BD0B261EC7640028A248 /* hb-ot-shape-complex-indic-table.cc */; };
 		F384BD59261EC7650028A248 /* hb-ot-map.cc in Sources */ = {isa = PBXBuildFile; fileRef = F384BD0C261EC7640028A248 /* hb-ot-map.cc */; };
-		F384BD5F261EC7650028A248 /* hb-ot-shape-complex-hangul.cc in Sources */ = {isa = PBXBuildFile; fileRef = F384BD0D261EC7640028A248 /* hb-ot-shape-complex-hangul.cc */; };
 		F384BD65261EC7650028A248 /* hb-ot-font.cc in Sources */ = {isa = PBXBuildFile; fileRef = F384BD0E261EC7640028A248 /* hb-ot-font.cc */; };
 		F384BD6B261EC7650028A248 /* hb-shape-plan.cc in Sources */ = {isa = PBXBuildFile; fileRef = F384BD0F261EC7640028A248 /* hb-shape-plan.cc */; };
 		F384BD71261EC7650028A248 /* hb-ot-tag.cc in Sources */ = {isa = PBXBuildFile; fileRef = F384BD10261EC7640028A248 /* hb-ot-tag.cc */; };
 		F384BD77261EC7650028A248 /* hb-number.cc in Sources */ = {isa = PBXBuildFile; fileRef = F384BD11261EC7640028A248 /* hb-number.cc */; };
 		F384BD7D261EC7650028A248 /* hb-ot-metrics.cc in Sources */ = {isa = PBXBuildFile; fileRef = F384BD12261EC7640028A248 /* hb-ot-metrics.cc */; };
 		F384BD83261EC7650028A248 /* hb-shaper.cc in Sources */ = {isa = PBXBuildFile; fileRef = F384BD13261EC7650028A248 /* hb-shaper.cc */; };
-		F384BD89261EC7650028A248 /* hb-ot-shape-complex-arabic.cc in Sources */ = {isa = PBXBuildFile; fileRef = F384BD14261EC7650028A248 /* hb-ot-shape-complex-arabic.cc */; };
-		F384BD8F261EC7650028A248 /* hb-ot-shape-complex-vowel-constraints.cc in Sources */ = {isa = PBXBuildFile; fileRef = F384BD15261EC7650028A248 /* hb-ot-shape-complex-vowel-constraints.cc */; };
 		F384BD95261EC7650028A248 /* hb-ot-layout.cc in Sources */ = {isa = PBXBuildFile; fileRef = F384BD16261EC7650028A248 /* hb-ot-layout.cc */; };
-		F384BD9B261EC7650028A248 /* hb-ot-shape-complex-thai.cc in Sources */ = {isa = PBXBuildFile; fileRef = F384BD17261EC7650028A248 /* hb-ot-shape-complex-thai.cc */; };
-		F384BDA1261EC7650028A248 /* hb-ot-shape-complex-indic.cc in Sources */ = {isa = PBXBuildFile; fileRef = F384BD18261EC7650028A248 /* hb-ot-shape-complex-indic.cc */; };
 		F384BDA7261EC7650028A248 /* hb-buffer-serialize.cc in Sources */ = {isa = PBXBuildFile; fileRef = F384BD19261EC7650028A248 /* hb-buffer-serialize.cc */; };
 		F384BDAD261EC7650028A248 /* hb-font.cc in Sources */ = {isa = PBXBuildFile; fileRef = F384BD1A261EC7650028A248 /* hb-font.cc */; };
-		F384BDB3261EC7650028A248 /* hb-ot-shape-complex-use.cc in Sources */ = {isa = PBXBuildFile; fileRef = F384BD1B261EC7650028A248 /* hb-ot-shape-complex-use.cc */; };
 		F384BDB9261EC7650028A248 /* hb-unicode.cc in Sources */ = {isa = PBXBuildFile; fileRef = F384BD1C261EC7650028A248 /* hb-unicode.cc */; };
 		F384BDBF261EC7650028A248 /* hb-buffer.cc in Sources */ = {isa = PBXBuildFile; fileRef = F384BD1D261EC7650028A248 /* hb-buffer.cc */; };
 		F384BDC5261EC7650028A248 /* hb-ot-cff2-table.cc in Sources */ = {isa = PBXBuildFile; fileRef = F384BD1E261EC7650028A248 /* hb-ot-cff2-table.cc */; };
 		F384BDCB261EC7650028A248 /* hb-ot-face.cc in Sources */ = {isa = PBXBuildFile; fileRef = F384BD1F261EC7650028A248 /* hb-ot-face.cc */; };
-		F384BDD1261EC7650028A248 /* hb-ot-shape-complex-khmer.cc in Sources */ = {isa = PBXBuildFile; fileRef = F384BD20261EC7650028A248 /* hb-ot-shape-complex-khmer.cc */; };
-		F384BDD7261EC7650028A248 /* hb-ot-shape-complex-myanmar.cc in Sources */ = {isa = PBXBuildFile; fileRef = F384BD21261EC7650028A248 /* hb-ot-shape-complex-myanmar.cc */; };
 		F384BDDD261EC7650028A248 /* hb-aat-layout.cc in Sources */ = {isa = PBXBuildFile; fileRef = F384BD22261EC7650028A248 /* hb-aat-layout.cc */; };
 		F384BDE3261EC7650028A248 /* hb-common.cc in Sources */ = {isa = PBXBuildFile; fileRef = F384BD23261EC7650028A248 /* hb-common.cc */; };
 		F384BDE9261EC7650028A248 /* hb-ot-cff1-table.cc in Sources */ = {isa = PBXBuildFile; fileRef = F384BD24261EC7650028A248 /* hb-ot-cff1-table.cc */; };
@@ -122,7 +134,6 @@
 		F384BE13261EC7650028A248 /* hb-ot-math.cc in Sources */ = {isa = PBXBuildFile; fileRef = F384BD2B261EC7650028A248 /* hb-ot-math.cc */; };
 		F384BE19261EC7650028A248 /* hb-ot-shape-fallback.cc in Sources */ = {isa = PBXBuildFile; fileRef = F384BD2C261EC7650028A248 /* hb-ot-shape-fallback.cc */; };
 		F384BE1F261EC7650028A248 /* hb-ot-shape.cc in Sources */ = {isa = PBXBuildFile; fileRef = F384BD2D261EC7650028A248 /* hb-ot-shape.cc */; };
-		F384BE25261EC7650028A248 /* hb-ot-shape-complex-syllabic.cc in Sources */ = {isa = PBXBuildFile; fileRef = F384BD2E261EC7650028A248 /* hb-ot-shape-complex-syllabic.cc */; };
 		F384BE48261EC9470028A248 /* hb-fallback-shape.cc in Sources */ = {isa = PBXBuildFile; fileRef = F384BE47261EC9470028A248 /* hb-fallback-shape.cc */; };
 		F384BE62261ECD9F0028A248 /* HarfBuzz-LICENSE.txt in Resources */ = {isa = PBXBuildFile; fileRef = F384BE60261ECD9F0028A248 /* HarfBuzz-LICENSE.txt */; };
 		F384BE65261ECD9F0028A248 /* FreeType-LICENSE.txt in Resources */ = {isa = PBXBuildFile; fileRef = F384BE61261ECD9F0028A248 /* FreeType-LICENSE.txt */; };
@@ -149,6 +160,30 @@
 
 /* Begin PBXFileReference section */
 		1014BAEA010A4B677F000001 /* SDL_ttf.h */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.c.h; name = SDL_ttf.h; path = ../include/SDL3_ttf/SDL_ttf.h; sourceTree = SOURCE_ROOT; };
+		61047E8D2B48AD0D00868128 /* hb-ot-shaper-syllabic.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-ot-shaper-syllabic.cc"; path = "../external/harfbuzz/src/hb-ot-shaper-syllabic.cc"; sourceTree = "<group>"; };
+		61047E8E2B48AD0D00868128 /* hb-paint-extents.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-paint-extents.cc"; path = "../external/harfbuzz/src/hb-paint-extents.cc"; sourceTree = "<group>"; };
+		61047E8F2B48AD0D00868128 /* hb-ot-name.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-ot-name.cc"; path = "../external/harfbuzz/src/hb-ot-name.cc"; sourceTree = "<group>"; };
+		61047E902B48AD0D00868128 /* hb-coretext.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-coretext.cc"; path = "../external/harfbuzz/src/hb-coretext.cc"; sourceTree = "<group>"; };
+		61047E912B48AD0D00868128 /* hb-paint.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-paint.cc"; path = "../external/harfbuzz/src/hb-paint.cc"; sourceTree = "<group>"; };
+		61047E922B48AD0E00868128 /* hb-face-builder.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-face-builder.cc"; path = "../external/harfbuzz/src/hb-face-builder.cc"; sourceTree = "<group>"; };
+		61047E932B48AD0E00868128 /* hb-ot-shaper-arabic.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-ot-shaper-arabic.cc"; path = "../external/harfbuzz/src/hb-ot-shaper-arabic.cc"; sourceTree = "<group>"; };
+		61047E942B48AD0E00868128 /* hb-draw.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-draw.cc"; path = "../external/harfbuzz/src/hb-draw.cc"; sourceTree = "<group>"; };
+		61047E952B48AD0E00868128 /* hb-ot-shaper-indic.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-ot-shaper-indic.cc"; path = "../external/harfbuzz/src/hb-ot-shaper-indic.cc"; sourceTree = "<group>"; };
+		61047E962B48AD0E00868128 /* hb-ot-shaper-indic-table.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-ot-shaper-indic-table.cc"; path = "../external/harfbuzz/src/hb-ot-shaper-indic-table.cc"; sourceTree = "<group>"; };
+		61047E972B48AD0E00868128 /* hb-style.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-style.cc"; path = "../external/harfbuzz/src/hb-style.cc"; sourceTree = "<group>"; };
+		61047E982B48AD0E00868128 /* hb-ot-shaper-use.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-ot-shaper-use.cc"; path = "../external/harfbuzz/src/hb-ot-shaper-use.cc"; sourceTree = "<group>"; };
+		61047E992B48AD0E00868128 /* hb-ot-shaper-khmer.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-ot-shaper-khmer.cc"; path = "../external/harfbuzz/src/hb-ot-shaper-khmer.cc"; sourceTree = "<group>"; };
+		61047E9A2B48AD0E00868128 /* hb-ot-shaper-vowel-constraints.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-ot-shaper-vowel-constraints.cc"; path = "../external/harfbuzz/src/hb-ot-shaper-vowel-constraints.cc"; sourceTree = "<group>"; };
+		61047E9B2B48AD0E00868128 /* hb-ot-shaper-hangul.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-ot-shaper-hangul.cc"; path = "../external/harfbuzz/src/hb-ot-shaper-hangul.cc"; sourceTree = "<group>"; };
+		61047E9C2B48AD0E00868128 /* hb-ot-meta.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-ot-meta.cc"; path = "../external/harfbuzz/src/hb-ot-meta.cc"; sourceTree = "<group>"; };
+		61047E9D2B48AD0F00868128 /* hb-ot-shaper-thai.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-ot-shaper-thai.cc"; path = "../external/harfbuzz/src/hb-ot-shaper-thai.cc"; sourceTree = "<group>"; };
+		61047E9E2B48AD0F00868128 /* hb-ot-shaper-hebrew.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-ot-shaper-hebrew.cc"; path = "../external/harfbuzz/src/hb-ot-shaper-hebrew.cc"; sourceTree = "<group>"; };
+		61047E9F2B48AD0F00868128 /* hb-outline.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-outline.cc"; path = "../external/harfbuzz/src/hb-outline.cc"; sourceTree = "<group>"; };
+		61047EA02B48AD0F00868128 /* hb-ot-shaper-default.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-ot-shaper-default.cc"; path = "../external/harfbuzz/src/hb-ot-shaper-default.cc"; sourceTree = "<group>"; };
+		61047EA12B48AD0F00868128 /* hb-directwrite.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-directwrite.cc"; path = "../external/harfbuzz/src/hb-directwrite.cc"; sourceTree = "<group>"; };
+		61047EA22B48AD0F00868128 /* hb-ot-shaper-myanmar.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-ot-shaper-myanmar.cc"; path = "../external/harfbuzz/src/hb-ot-shaper-myanmar.cc"; sourceTree = "<group>"; };
+		61047EA32B48AD0F00868128 /* hb-ot-color.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-ot-color.cc"; path = "../external/harfbuzz/src/hb-ot-color.cc"; sourceTree = "<group>"; };
+		61047EBB2B48AF9700868128 /* hb-buffer-verify.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-buffer-verify.cc"; path = "../external/harfbuzz/src/hb-buffer-verify.cc"; sourceTree = "<group>"; };
 		7FC2F5DB285AC0D600836845 /* CMake */ = {isa = PBXFileReference; lastKnownFileType = folder; path = CMake; sourceTree = "<group>"; };
 		A75FDB0C23E37ED200529352 /* SDL3.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SDL3.framework; path = iOS/SDL3.framework; sourceTree = "<group>"; };
 		A75FDB1023E37EE400529352 /* SDL3.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SDL3.framework; path = tvOS/SDL3.framework; sourceTree = "<group>"; };
@@ -156,7 +191,6 @@
 		BE48FD6707AFA17000BB41DA /* SDL3_ttf.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SDL3_ttf.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		BE48FD8307AFA29000BB41DA /* SDL3.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = SDL3.framework; sourceTree = "<group>"; };
 		F307EE28282738F8003915D7 /* svg.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = svg.c; path = ../external/freetype/src/svg/svg.c; sourceTree = "<group>"; };
-		F307EE2B282807EB003915D7 /* hb-ms-feature-ranges.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-ms-feature-ranges.cc"; path = "../external/harfbuzz/src/hb-ms-feature-ranges.cc"; sourceTree = "<group>"; };
 		F364A5B72620E1A200325ECE /* FTL.TXT */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = FTL.TXT; path = ../../../external/freetype/docs/FTL.TXT; sourceTree = "<group>"; };
 		F364A5C32620E22400325ECE /* ReadMe.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = ReadMe.txt; sourceTree = "<group>"; };
 		F3696FE3278F7107003A7F94 /* sdf.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = sdf.c; path = ../external/freetype/src/sdf/sdf.c; sourceTree = "<group>"; };
@@ -200,35 +234,24 @@
 		F384BCD3261EC2BE0028A248 /* type42.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = type42.c; path = ../external/freetype/src/type42/type42.c; sourceTree = "<group>"; };
 		F384BCDE261EC2CF0028A248 /* winfnt.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = winfnt.c; path = ../external/freetype/src/winfonts/winfnt.c; sourceTree = "<group>"; };
 		F384BCF1261EC5130028A248 /* ftcache.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = ftcache.c; path = ../external/freetype/src/cache/ftcache.c; sourceTree = "<group>"; };
-		F384BD05261EC7640028A248 /* hb-ot-shape-complex-default.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-ot-shape-complex-default.cc"; path = "../external/harfbuzz/src/hb-ot-shape-complex-default.cc"; sourceTree = "<group>"; };
 		F384BD06261EC7640028A248 /* hb-set.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-set.cc"; path = "../external/harfbuzz/src/hb-set.cc"; sourceTree = "<group>"; };
 		F384BD07261EC7640028A248 /* hb-shape.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-shape.cc"; path = "../external/harfbuzz/src/hb-shape.cc"; sourceTree = "<group>"; };
 		F384BD08261EC7640028A248 /* hb-static.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-static.cc"; path = "../external/harfbuzz/src/hb-static.cc"; sourceTree = "<group>"; };
-		F384BD09261EC7640028A248 /* hb-ot-shape-complex-hebrew.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-ot-shape-complex-hebrew.cc"; path = "../external/harfbuzz/src/hb-ot-shape-complex-hebrew.cc"; sourceTree = "<group>"; };
 		F384BD0A261EC7640028A248 /* hb-ucd.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-ucd.cc"; path = "../external/harfbuzz/src/hb-ucd.cc"; sourceTree = "<group>"; };
-		F384BD0B261EC7640028A248 /* hb-ot-shape-complex-indic-table.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-ot-shape-complex-indic-table.cc"; path = "../external/harfbuzz/src/hb-ot-shape-complex-indic-table.cc"; sourceTree = "<group>"; };
 		F384BD0C261EC7640028A248 /* hb-ot-map.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-ot-map.cc"; path = "../external/harfbuzz/src/hb-ot-map.cc"; sourceTree = "<group>"; };
-		F384BD0D261EC7640028A248 /* hb-ot-shape-complex-hangul.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-ot-shape-complex-hangul.cc"; path = "../external/harfbuzz/src/hb-ot-shape-complex-hangul.cc"; sourceTree = "<group>"; };
 		F384BD0E261EC7640028A248 /* hb-ot-font.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-ot-font.cc"; path = "../external/harfbuzz/src/hb-ot-font.cc"; sourceTree = "<group>"; };
 		F384BD0F261EC7640028A248 /* hb-shape-plan.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-shape-plan.cc"; path = "../external/harfbuzz/src/hb-shape-plan.cc"; sourceTree = "<group>"; };
 		F384BD10261EC7640028A248 /* hb-ot-tag.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-ot-tag.cc"; path = "../external/harfbuzz/src/hb-ot-tag.cc"; sourceTree = "<group>"; };
 		F384BD11261EC7640028A248 /* hb-number.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-number.cc"; path = "../external/harfbuzz/src/hb-number.cc"; sourceTree = "<group>"; };
 		F384BD12261EC7640028A248 /* hb-ot-metrics.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-ot-metrics.cc"; path = "../external/harfbuzz/src/hb-ot-metrics.cc"; sourceTree = "<group>"; };
 		F384BD13261EC7650028A248 /* hb-shaper.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-shaper.cc"; path = "../external/harfbuzz/src/hb-shaper.cc"; sourceTree = "<group>"; };
-		F384BD14261EC7650028A248 /* hb-ot-shape-complex-arabic.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-ot-shape-complex-arabic.cc"; path = "../external/harfbuzz/src/hb-ot-shape-complex-arabic.cc"; sourceTree = "<group>"; };
-		F384BD15261EC7650028A248 /* hb-ot-shape-complex-vowel-constraints.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-ot-shape-complex-vowel-constraints.cc"; path = "../external/harfbuzz/src/hb-ot-shape-complex-vowel-constraints.cc"; sourceTree = "<group>"; };
 		F384BD16261EC7650028A248 /* hb-ot-layout.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-ot-layout.cc"; path = "../external/harfbuzz/src/hb-ot-layout.cc"; sourceTree = "<group>"; };
-		F384BD17261EC7650028A248 /* hb-ot-shape-complex-thai.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-ot-shape-complex-thai.cc"; path = "../external/harfbuzz/src/hb-ot-shape-complex-thai.cc"; sourceTree = "<group>"; };
-		F384BD18261EC7650028A248 /* hb-ot-shape-complex-indic.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-ot-shape-complex-indic.cc"; path = "../external/harfbuzz/src/hb-ot-shape-complex-indic.cc"; sourceTree = "<group>"; };
 		F384BD19261EC7650028A248 /* hb-buffer-serialize.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-buffer-serialize.cc"; path = "../external/harfbuzz/src/hb-buffer-serialize.cc"; sourceTree = "<group>"; };
 		F384BD1A261EC7650028A248 /* hb-font.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-font.cc"; path = "../external/harfbuzz/src/hb-font.cc"; sourceTree = "<group>"; };
-		F384BD1B261EC7650028A248 /* hb-ot-shape-complex-use.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-ot-shape-complex-use.cc"; path = "../external/harfbuzz/src/hb-ot-shape-complex-use.cc"; sourceTree = "<group>"; };
 		F384BD1C261EC7650028A248 /* hb-unicode.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-unicode.cc"; path = "../external/harfbuzz/src/hb-unicode.cc"; sourceTree = "<group>"; };
 		F384BD1D261EC7650028A248 /* hb-buffer.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-buffer.cc"; path = "../external/harfbuzz/src/hb-buffer.cc"; sourceTree = "<group>"; };
 		F384BD1E261EC7650028A248 /* hb-ot-cff2-table.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-ot-cff2-table.cc"; path = "../external/harfbuzz/src/hb-ot-cff2-table.cc"; sourceTree = "<group>"; };
 		F384BD1F261EC7650028A248 /* hb-ot-face.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-ot-face.cc"; path = "../external/harfbuzz/src/hb-ot-face.cc"; sourceTree = "<group>"; };
-		F384BD20261EC7650028A248 /* hb-ot-shape-complex-khmer.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-ot-shape-complex-khmer.cc"; path = "../external/harfbuzz/src/hb-ot-shape-complex-khmer.cc"; sourceTree = "<group>"; };
-		F384BD21261EC7650028A248 /* hb-ot-shape-complex-myanmar.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-ot-shape-complex-myanmar.cc"; path = "../external/harfbuzz/src/hb-ot-shape-complex-myanmar.cc"; sourceTree = "<group>"; };
 		F384BD22261EC7650028A248 /* hb-aat-layout.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-aat-layout.cc"; path = "../external/harfbuzz/src/hb-aat-layout.cc"; sourceTree = "<group>"; };
 		F384BD23261EC7650028A248 /* hb-common.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-common.cc"; path = "../external/harfbuzz/src/hb-common.cc"; sourceTree = "<group>"; };
 		F384BD24261EC7650028A248 /* hb-ot-cff1-table.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-ot-cff1-table.cc"; path = "../external/harfbuzz/src/hb-ot-cff1-table.cc"; sourceTree = "<group>"; };
@@ -241,7 +264,6 @@
 		F384BD2B261EC7650028A248 /* hb-ot-math.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-ot-math.cc"; path = "../external/harfbuzz/src/hb-ot-math.cc"; sourceTree = "<group>"; };
 		F384BD2C261EC7650028A248 /* hb-ot-shape-fallback.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-ot-shape-fallback.cc"; path = "../external/harfbuzz/src/hb-ot-shape-fallback.cc"; sourceTree = "<group>"; };
 		F384BD2D261EC7650028A248 /* hb-ot-shape.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-ot-shape.cc"; path = "../external/harfbuzz/src/hb-ot-shape.cc"; sourceTree = "<group>"; };
-		F384BD2E261EC7650028A248 /* hb-ot-shape-complex-syllabic.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-ot-shape-complex-syllabic.cc"; path = "../external/harfbuzz/src/hb-ot-shape-complex-syllabic.cc"; sourceTree = "<group>"; };
 		F384BE47261EC9470028A248 /* hb-fallback-shape.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-fallback-shape.cc"; path = "../external/harfbuzz/src/hb-fallback-shape.cc"; sourceTree = "<group>"; };
 		F384BE60261ECD9F0028A248 /* HarfBuzz-LICENSE.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = "HarfBuzz-LICENSE.txt"; sourceTree = "<group>"; };
 		F384BE61261ECD9F0028A248 /* FreeType-LICENSE.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = "FreeType-LICENSE.txt"; sourceTree = "<group>"; };
@@ -406,6 +428,30 @@
 		F384BD04261EC64F0028A248 /* HarfBuzz */ = {
 			isa = PBXGroup;
 			children = (
+				61047EBB2B48AF9700868128 /* hb-buffer-verify.cc */,
+				61047E902B48AD0D00868128 /* hb-coretext.cc */,
+				61047EA12B48AD0F00868128 /* hb-directwrite.cc */,
+				61047E942B48AD0E00868128 /* hb-draw.cc */,
+				61047E922B48AD0E00868128 /* hb-face-builder.cc */,
+				61047EA32B48AD0F00868128 /* hb-ot-color.cc */,
+				61047E9C2B48AD0E00868128 /* hb-ot-meta.cc */,
+				61047E8F2B48AD0D00868128 /* hb-ot-name.cc */,
+				61047E932B48AD0E00868128 /* hb-ot-shaper-arabic.cc */,
+				61047EA02B48AD0F00868128 /* hb-ot-shaper-default.cc */,
+				61047E9B2B48AD0E00868128 /* hb-ot-shaper-hangul.cc */,
+				61047E9E2B48AD0F00868128 /* hb-ot-shaper-hebrew.cc */,
+				61047E962B48AD0E00868128 /* hb-ot-shaper-indic-table.cc */,
+				61047E952B48AD0E00868128 /* hb-ot-shaper-indic.cc */,
+				61047E992B48AD0E00868128 /* hb-ot-shaper-khmer.cc */,
+				61047EA22B48AD0F00868128 /* hb-ot-shaper-myanmar.cc */,
+				61047E8D2B48AD0D00868128 /* hb-ot-shaper-syllabic.cc */,
+				61047E9D2B48AD0F00868128 /* hb-ot-shaper-thai.cc */,
+				61047E982B48AD0E00868128 /* hb-ot-shaper-use.cc */,
+				61047E9A2B48AD0E00868128 /* hb-ot-shaper-vowel-constraints.cc */,
+				61047E9F2B48AD0F00868128 /* hb-outline.cc */,
+				61047E8E2B48AD0D00868128 /* hb-paint-extents.cc */,
+				61047E912B48AD0D00868128 /* hb-paint.cc */,
+				61047E972B48AD0E00868128 /* hb-style.cc */,
 				F384BD22261EC7650028A248 /* hb-aat-layout.cc */,
 				F384BD27261EC7650028A248 /* hb-aat-map.cc */,
 				F384BD26261EC7650028A248 /* hb-blob.cc */,
@@ -416,7 +462,6 @@
 				F384BE47261EC9470028A248 /* hb-fallback-shape.cc */,
 				F384BD1A261EC7650028A248 /* hb-font.cc */,
 				F384BD28261EC7650028A248 /* hb-ft.cc */,
-				F307EE2B282807EB003915D7 /* hb-ms-feature-ranges.cc */,
 				F384BD11261EC7640028A248 /* hb-number.cc */,
 				F384BD24261EC7650028A248 /* hb-ot-cff1-table.cc */,
 				F384BD1E261EC7650028A248 /* hb-ot-cff2-table.cc */,
@@ -426,18 +471,6 @@
 				F384BD0C261EC7640028A248 /* hb-ot-map.cc */,
 				F384BD2B261EC7650028A248 /* hb-ot-math.cc */,
 				F384BD12261EC7640028A248 /* hb-ot-metrics.cc */,
-				F384BD14261EC7650028A248 /* hb-ot-shape-complex-arabic.cc */,
-				F384BD05261EC7640028A248 /* hb-ot-shape-complex-default.cc */,
-				F384BD0D261EC7640028A248 /* hb-ot-shape-complex-hangul.cc */,
-				F384BD09261EC7640028A248 /* hb-ot-shape-complex-hebrew.cc */,
-				F384BD0B261EC7640028A248 /* hb-ot-shape-complex-indic-table.cc */,
-				F384BD18261EC7650028A248 /* hb-ot-shape-complex-indic.cc */,
-				F384BD20261EC7650028A248 /* hb-ot-shape-complex-khmer.cc */,
-				F384BD21261EC7650028A248 /* hb-ot-shape-complex-myanmar.cc */,
-				F384BD2E261EC7650028A248 /* hb-ot-shape-complex-syllabic.cc */,
-				F384BD17261EC7650028A248 /* hb-ot-shape-complex-thai.cc */,
-				F384BD1B261EC7650028A248 /* hb-ot-shape-complex-use.cc */,
-				F384BD15261EC7650028A248 /* hb-ot-shape-complex-vowel-constraints.cc */,
 				F384BD2C261EC7650028A248 /* hb-ot-shape-fallback.cc */,
 				F384BD29261EC7650028A248 /* hb-ot-shape-normalize.cc */,
 				F384BD2D261EC7650028A248 /* hb-ot-shape.cc */,
@@ -640,16 +673,14 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				61047EBC2B48AF9700868128 /* hb-buffer-verify.cc in Sources */,
 				F384BB8B261EC0DE0028A248 /* ftbdf.c in Sources */,
-				F384BD8F261EC7650028A248 /* hb-ot-shape-complex-vowel-constraints.cc in Sources */,
 				F384BBBB261EC0DE0028A248 /* ftglyph.c in Sources */,
 				F384BC3A261EC1890028A248 /* type1cid.c in Sources */,
 				F384BC71261EC2050028A248 /* psaux.c in Sources */,
 				F384BD35261EC7650028A248 /* hb-set.cc in Sources */,
 				F384BC9D261EC2680028A248 /* sfnt.c in Sources */,
 				F384BDE9261EC7650028A248 /* hb-ot-cff1-table.cc in Sources */,
-				F384BE25261EC7650028A248 /* hb-ot-shape-complex-syllabic.cc in Sources */,
-				F384BDD1261EC7650028A248 /* hb-ot-shape-complex-khmer.cc in Sources */,
 				F384BCBE261EC2980028A248 /* truetype.c in Sources */,
 				F384BD59261EC7650028A248 /* hb-ot-map.cc in Sources */,
 				F384BBD9261EC0DE0028A248 /* ftcid.c in Sources */,
@@ -662,41 +693,54 @@
 				F384BDA7261EC7650028A248 /* hb-buffer-serialize.cc in Sources */,
 				F384BBC1261EC0DE0028A248 /* ftsynth.c in Sources */,
 				F384BE07261EC7650028A248 /* hb-ot-shape-normalize.cc in Sources */,
+				61047EB32B48AD0F00868128 /* hb-ot-meta.cc in Sources */,
 				F384BD41261EC7650028A248 /* hb-static.cc in Sources */,
 				F384BD77261EC7650028A248 /* hb-number.cc in Sources */,
+				61047EB02B48AD0F00868128 /* hb-ot-shaper-khmer.cc in Sources */,
 				F384BBCD261EC0DE0028A248 /* ftinit.c in Sources */,
 				F384BE1F261EC7650028A248 /* hb-ot-shape.cc in Sources */,
-				F384BDD7261EC7650028A248 /* hb-ot-shape-complex-myanmar.cc in Sources */,
+				61047EBA2B48AD0F00868128 /* hb-ot-color.cc in Sources */,
+				61047EB42B48AD0F00868128 /* hb-ot-shaper-thai.cc in Sources */,
+				61047EA42B48AD0F00868128 /* hb-ot-shaper-syllabic.cc in Sources */,
 				F384BD6B261EC7650028A248 /* hb-shape-plan.cc in Sources */,
 				F384BBAF261EC0DE0028A248 /* ftbase.c in Sources */,
 				F384BC5B261EC1DF0028A248 /* pcf.c in Sources */,
 				F384BC50261EC1B90028A248 /* ftlzw.c in Sources */,
 				F384BBF1261EC0DE0028A248 /* ftsystem.c in Sources */,
 				F384BBDF261EC0DE0028A248 /* ftpfr.c in Sources */,
-				F384BDB3261EC7650028A248 /* hb-ot-shape-complex-use.cc in Sources */,
+				61047EB22B48AD0F00868128 /* hb-ot-shaper-hangul.cc in Sources */,
+				61047EAD2B48AD0F00868128 /* hb-ot-shaper-indic-table.cc in Sources */,
+				61047EAE2B48AD0F00868128 /* hb-style.cc in Sources */,
 				F384BDC5261EC7650028A248 /* hb-ot-cff2-table.cc in Sources */,
 				F384BE13261EC7650028A248 /* hb-ot-math.cc in Sources */,
 				F384BBD3261EC0DE0028A248 /* ftmm.c in Sources */,
 				F384BD71261EC7650028A248 /* hb-ot-tag.cc in Sources */,
 				F384BC03261EC0DE0028A248 /* fttype1.c in Sources */,
+				61047EA72B48AD0F00868128 /* hb-coretext.cc in Sources */,
 				F384BB9D261EC0DE0028A248 /* ftstroke.c in Sources */,
-				F384BD5F261EC7650028A248 /* hb-ot-shape-complex-hangul.cc in Sources */,
 				F384BC45261EC1A30028A248 /* ftgzip.c in Sources */,
 				F307EE29282738F8003915D7 /* svg.c in Sources */,
 				F384BB6C261EC0760028A248 /* autofit.c in Sources */,
-				F384BD53261EC7650028A248 /* hb-ot-shape-complex-indic-table.cc in Sources */,
 				F384BDFB261EC7650028A248 /* hb-aat-map.cc in Sources */,
+				61047EAB2B48AD0F00868128 /* hb-draw.cc in Sources */,
 				F384BB91261EC0DE0028A248 /* ftgasp.c in Sources */,
+				61047EAF2B48AD0F00868128 /* hb-ot-shaper-use.cc in Sources */,
+				61047EB62B48AD0F00868128 /* hb-outline.cc in Sources */,
 				F384BBF7261EC0DE0028A248 /* ftwinfnt.c in Sources */,
+				61047EAA2B48AD0F00868128 /* hb-ot-shaper-arabic.cc in Sources */,
+				61047EA62B48AD0F00868128 /* hb-ot-name.cc in Sources */,
 				BE48FD6207AFA17000BB41DA /* SDL_ttf.c in Sources */,
-				F384BD89261EC7650028A248 /* hb-ot-shape-complex-arabic.cc in Sources */,
+				61047EB92B48AD0F00868128 /* hb-ot-shaper-myanmar.cc in Sources */,
 				F384BDE3261EC7650028A248 /* hb-common.cc in Sources */,
 				F384BD7D261EC7650028A248 /* hb-ot-metrics.cc in Sources */,
 				F384BDDD261EC7650028A248 /* hb-aat-layout.cc in Sources */,
+				61047EA92B48AD0F00868128 /* hb-face-builder.cc in Sources */,
+				61047EB82B48AD0F00868128 /* hb-directwrite.cc in Sources */,
+				61047EA52B48AD0F00868128 /* hb-paint-extents.cc in Sources */,
 				F384BDF5261EC7650028A248 /* hb-blob.cc in Sources */,
-				F384BD9B261EC7650028A248 /* hb-ot-shape-complex-thai.cc in Sources */,
 				F384BCC9261EC2AE0028A248 /* type1.c in Sources */,
 				F384BD3B261EC7650028A248 /* hb-shape.cc in Sources */,
+				61047EA82B48AD0F00868128 /* hb-paint.cc in Sources */,
 				F384BC92261EC2560028A248 /* raster.c in Sources */,
 				F384BDCB261EC7650028A248 /* hb-ot-face.cc in Sources */,
 				F384BB97261EC0DE0028A248 /* ftgxval.c in Sources */,
@@ -707,24 +751,24 @@
 				F384BE01261EC7650028A248 /* hb-ft.cc in Sources */,
 				F384BE19261EC7650028A248 /* hb-ot-shape-fallback.cc in Sources */,
 				F384BD95261EC7650028A248 /* hb-ot-layout.cc in Sources */,
-				F307EE2C282807EB003915D7 /* hb-ms-feature-ranges.cc in Sources */,
 				F384BC0E261EC0F90028A248 /* bdf.c in Sources */,
 				F384BC87261EC23B0028A248 /* psmodule.c in Sources */,
 				F384BE0D261EC7650028A248 /* hb-ot-var.cc in Sources */,
 				F384BBE5261EC0DE0028A248 /* ftotval.c in Sources */,
-				F384BD2F261EC7650028A248 /* hb-ot-shape-complex-default.cc in Sources */,
+				61047EB12B48AD0F00868128 /* hb-ot-shaper-vowel-constraints.cc in Sources */,
 				F384BBEB261EC0DE0028A248 /* ftfstype.c in Sources */,
+				61047EAC2B48AD0F00868128 /* hb-ot-shaper-indic.cc in Sources */,
 				F384BC7C261EC2180028A248 /* pshinter.c in Sources */,
 				F384BD65261EC7650028A248 /* hb-ot-font.cc in Sources */,
+				61047EB52B48AD0F00868128 /* hb-ot-shaper-hebrew.cc in Sources */,
 				F384BBC7261EC0DE0028A248 /* ftbitmap.c in Sources */,
 				F384BCA8261EC2770028A248 /* smooth.c in Sources */,
-				F384BD47261EC7650028A248 /* hb-ot-shape-complex-hebrew.cc in Sources */,
 				F384BBA9261EC0DE0028A248 /* ftbbox.c in Sources */,
 				F384BE48261EC9470028A248 /* hb-fallback-shape.cc in Sources */,
 				F384BBA3261EC0DE0028A248 /* ftdebug.c in Sources */,
+				61047EB72B48AD0F00868128 /* hb-ot-shaper-default.cc in Sources */,
 				F384BDB9261EC7650028A248 /* hb-unicode.cc in Sources */,
 				F384BC66261EC1F30028A248 /* pfr.c in Sources */,
-				F384BDA1261EC7650028A248 /* hb-ot-shape-complex-indic.cc in Sources */,
 				F384BC19261EC1440028A248 /* ftbzip2.c in Sources */,
 				F384BCF2261EC5130028A248 /* ftcache.c in Sources */,
 			);


### PR DESCRIPTION
The Xcode project was referring to some files that don't exist in the Harfbuzz project anymore, this commit also added some .cc files that were missing to build the library using Xcode.

PR Ref: #326 (SDL2)