### PR TITLE
Prevent negative draw line and out of bounds.

### DIFF
--- a/src/SDL_ttf.c
+++ b/src/SDL_ttf.c
@@ -3895,6 +3895,7 @@ static SDL_Surface* TTF_Render_Wrapped_Internal(TTF_Font *font, const char *text
         } else {
             xoffset = 0;
         }
+        xoffset = SDL_max(0, xoffset);
 
         /* Render one text line to textbuf at (xstart, ystart) */
         if (Render_Line(render_mode, font->render_subpixel, font, textbuf, xstart + xoffset, ystart, fg) < 0) {


### PR DESCRIPTION
can be reproduced with testapp.c, int seed = 1704796537, at iteration ~270