### PR TITLE
Fixed bug #324 - prevent unaligned load access

### DIFF
--- a/src/SDL_ttf.c
+++ b/src/SDL_ttf.c
@@ -391,7 +391,9 @@ static SDL_INLINE void BG_Blended_Color(const TTF_Image *image, Uint32 *destinat
         while (height--) {
             /* *INDENT-OFF* */
             DUFFS_LOOP4(
-                    tmp = *src++;
+                    /* prevent misaligned load: tmp = *src++; */
+                    /* eventually, we can expect the compiler to replace the memcpy call with something optimized */
+                    memcpy(&tmp, src++, sizeof(tmp)); /* This should NOT be SDL_memcpy */
                     alpha = tmp >> 24;
                     tmp &= ~0xFF000000;
                     alpha = fg_alpha * alpha;
@@ -426,7 +428,8 @@ static SDL_INLINE void BG_Blended_LCD(const TTF_Image *image, Uint32 *destinatio
     while (height--) {
         /* *INDENT-OFF* */
         DUFFS_LOOP4(
-                tmp = *src++;
+                /* prevent misaligned load: tmp = *src++; */
+                memcpy(&tmp, src++, sizeof(tmp)); /* This should NOT be SDL_memcpy */
 
                 if (tmp) {
                     bg = *dst;
@@ -883,11 +886,14 @@ static SDL_INLINE void BG_64(const TTF_Image *image, Uint8 *destination, Sint32 
     Uint64       *dst    = (Uint64 *)destination;
     Uint32        width  = image->width / 8;
     Uint32        height = image->rows;
+    Uint64        tmp;
 
     while (height--) {
         /* *INDENT-OFF* */
         DUFFS_LOOP4(
-            *dst++ |= *src++;
+              /* prevent misaligned load: *dst++ |= *src++; */
+              memcpy(&tmp, src++, sizeof(tmp)); /* This should NOT be SDL_memcpy */
+              *dst++ |= tmp;
         , width);
         /* *INDENT-ON* */
         src = (const Uint64 *)((const Uint8 *)src + srcskip);
@@ -901,11 +907,14 @@ static SDL_INLINE void BG_32(const TTF_Image *image, Uint8 *destination, Sint32 
     Uint32       *dst    = (Uint32 *)destination;
     Uint32        width  = image->width / 4;
     Uint32        height = image->rows;
+    Uint32        tmp;
 
     while (height--) {
         /* *INDENT-OFF* */
         DUFFS_LOOP4(
-            *dst++ |= *src++;
+            /* prevent misaligned load: *dst++ |= *src++; */
+            memcpy(&tmp, src++, sizeof(tmp)); /* This should NOT be SDL_memcpy */
+            *dst++ |= tmp;
         , width);
         /* *INDENT-ON* */
         src = (const Uint32 *)((const Uint8 *)src + srcskip);


### PR DESCRIPTION
Fixed bug #324 - prevent unaligned load access
use memcpy so we can expect the compiler to optimize when possible