### PR TITLE
Fix ASAN reports: runtime error: left shift of XXX by 24 places cannot be represented in type 'int'

### DIFF
--- a/src/SDL_ttf.c
+++ b/src/SDL_ttf.c
@@ -485,7 +485,7 @@ static SDL_INLINE void BG_Blended_Opaque_SDF(const TTF_Image *image, Uint32 *des
         /* *INDENT-OFF* */
         DUFFS_LOOP4(
             d = *dst;
-            s = *src++ << 24;
+            s = ((Uint32)*src++) << 24;
             if (s > d) {
                 *dst = s;
             }
@@ -539,7 +539,7 @@ static SDL_INLINE void BG_Blended_Opaque(const TTF_Image *image, Uint32 *destina
     while (height--) {
         /* *INDENT-OFF* */
         DUFFS_LOOP4(
-            *dst++ |= *src++ << 24;
+            *dst++ |= ((Uint32)*src++) << 24;
         , width);
         /* *INDENT-ON* */
         src += srcskip;
@@ -580,10 +580,10 @@ static SDL_INLINE void BG_Blended_Opaque_32(const TTF_Image *image, Uint32 *dest
     while (height--) {
         /* *INDENT-OFF* */
         DUFFS_LOOP4(
-            *dst++ |= *src++ << 24;
-            *dst++ |= *src++ << 24;
-            *dst++ |= *src++ << 24;
-            *dst++ |= *src++ << 24;
+            *dst++ |= ((Uint32)*src++) << 24;
+            *dst++ |= ((Uint32)*src++) << 24;
+            *dst++ |= ((Uint32)*src++) << 24;
+            *dst++ |= ((Uint32)*src++) << 24;
         , width);
         /* *INDENT-ON* */
         src += srcskip;
@@ -1551,7 +1551,7 @@ static SDL_Surface *Create_Surface_Blended(int width, int height, SDL_Color fg, 
     bgcolor = (fg.r << 16) | (fg.g << 8) | fg.b;
 
     /* Underline/Strikethrough color style */
-    *color = bgcolor | (fg.a << 24);
+    *color = bgcolor | ((Uint32)fg.a << 24);
 
     /* Create the target surface if required */
     if (width != 0) {
@@ -1575,10 +1575,10 @@ static SDL_Surface* Create_Surface_LCD(int width, int height, SDL_Color fg, SDL_
     Uint32 bgcolor;
 
     /* Background color */
-    bgcolor = (bg.a << 24) | (bg.r << 16) | (bg.g << 8) | bg.b;
+    bgcolor = (((Uint32)bg.a) << 24) | (bg.r << 16) | (bg.g << 8) | bg.b;
 
     /* Underline/Strikethrough color style */
-    *color = (bg.a << 24) | (fg.r << 16) | (fg.g << 8) | fg.b;
+    *color = (((Uint32)bg.a) << 24) | (fg.r << 16) | (fg.g << 8) | fg.b;
 
     /* Create the target surface if required */
     if (width != 0) {


### PR DESCRIPTION
Fix ASAN reports: runtime error: left shift of XXX by 24 places cannot be represented in type 'int'