### PR TITLE
upgrade vendored freetype to 2.13.2 with fixes

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "external/freetype"]
 	path = external/freetype
 	url = https://github.com/libsdl-org/freetype.git
-	branch = VER-2-13-0-SDL
+	branch = VER-2-13-2-SDL
 [submodule "external/harfbuzz"]
 	path = external/harfbuzz
 	url = https://github.com/libsdl-org/harfbuzz.git


### PR DESCRIPTION
Fixes #332 

Freetype is forked not from the 2.13.2 tag intentionally, but from 9 post-release commits instead to catch-up with fixes, and a few fixes from master are additionally cherry-picked. See comparison:
https://github.com/libsdl-org/freetype/compare/VER-2-13-2...libsdl-org:freetype:VER-2-13-2-SDL

If this is good, it should cherry-pick to SDL3 cleanly.
