### PR TITLE
Some improvements and fixes specifically for VisualC

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -26,7 +26,7 @@ BreakBeforeBraces: Custom
 BraceWrapping:
   AfterCaseLabel: true
   AfterClass: true
-  AfterControlStatement: true
+  AfterControlStatement: Never
   AfterEnum: true
   AfterFunction: true
   AfterNamespace: true

--- a/.clang-format
+++ b/.clang-format
@@ -26,7 +26,7 @@ BreakBeforeBraces: Custom
 BraceWrapping:
   AfterCaseLabel: true
   AfterClass: true
-  AfterControlStatement: Never
+  AfterControlStatement: true
   AfterEnum: true
   AfterFunction: true
   AfterNamespace: true

--- a/VisualC/SDL_ttf.vcxproj
+++ b/VisualC/SDL_ttf.vcxproj
@@ -117,6 +117,7 @@
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>OldStyle</DebugInformationFormat>
       <EnableEnhancedInstructionSet>StreamingSIMDExtensions</EnableEnhancedInstructionSet>
+      <AdditionalIncludeDirectories>K:\ProjectsMine\SDL_ttf\external\SDL\include</AdditionalIncludeDirectories>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -144,13 +145,14 @@
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>OldStyle</DebugInformationFormat>
+      <AdditionalIncludeDirectories>K:\ProjectsMine\SDL_ttf\external\SDL\include</AdditionalIncludeDirectories>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ResourceCompile>
     <Link>
       <AdditionalDependencies>SDL3.lib;ucrtd.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <AdditionalLibraryDirectories>external\lib\x64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>external\lib\x64;K:\ProjectsMine\SDL_ttf\external\SDL\VisualC\x64\Debug;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>Windows</SubSystem>
     </Link>
@@ -170,6 +172,7 @@
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <WarningLevel>Level3</WarningLevel>
       <EnableEnhancedInstructionSet>StreamingSIMDExtensions</EnableEnhancedInstructionSet>
+      <AdditionalIncludeDirectories>K:\ProjectsMine\SDL_ttf\external\SDL\include</AdditionalIncludeDirectories>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -194,13 +197,14 @@
       <PreprocessorDefinitions>DLL_EXPORT;WIN32;NDEBUG;_WINDOWS;_CRT_SECURE_NO_WARNINGS;TTF_USE_HARFBUZZ=1;FT_PUBLIC_FUNCTION_ATTRIBUTE=;FT_CONFIG_OPTION_USE_HARFBUZZ;FT2_BUILD_LIBRARY;HAVE_FREETYPE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <WarningLevel>Level3</WarningLevel>
+      <AdditionalIncludeDirectories>K:\ProjectsMine\SDL_ttf\external\SDL\include</AdditionalIncludeDirectories>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ResourceCompile>
     <Link>
       <AdditionalDependencies>SDL3.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <AdditionalLibraryDirectories>external\lib\x64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>external\lib\x64;K:\ProjectsMine\SDL_ttf\external\SDL\VisualC\x64\Release;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <SubSystem>Windows</SubSystem>
     </Link>
   </ItemDefinitionGroup>

--- a/VisualC/SDL_ttf.vcxproj
+++ b/VisualC/SDL_ttf.vcxproj
@@ -117,13 +117,14 @@
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>OldStyle</DebugInformationFormat>
       <EnableEnhancedInstructionSet>StreamingSIMDExtensions</EnableEnhancedInstructionSet>
+      <AdditionalIncludeDirectories>$(SolutionDir)..\external\SDL\include</AdditionalIncludeDirectories>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ResourceCompile>
     <Link>
       <AdditionalDependencies>SDL3.lib;ucrtd.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <AdditionalLibraryDirectories>external\lib\x86;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>external\lib\$(PlatformTarget);$(SolutionDir)..\external\SDL\VisualC\$(Platform)\$(Configuration)\;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>Windows</SubSystem>
     </Link>
@@ -144,13 +145,14 @@
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>OldStyle</DebugInformationFormat>
+      <AdditionalIncludeDirectories>$(SolutionDir)..\external\SDL\include</AdditionalIncludeDirectories>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ResourceCompile>
     <Link>
       <AdditionalDependencies>SDL3.lib;ucrtd.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <AdditionalLibraryDirectories>external\lib\x64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>external\lib\$(PlatformTarget);$(SolutionDir)..\external\SDL\VisualC\$(Platform)\$(Configuration)\;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>Windows</SubSystem>
     </Link>
@@ -170,13 +172,14 @@
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <WarningLevel>Level3</WarningLevel>
       <EnableEnhancedInstructionSet>StreamingSIMDExtensions</EnableEnhancedInstructionSet>
+      <AdditionalIncludeDirectories>$(SolutionDir)..\external\SDL\include</AdditionalIncludeDirectories>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ResourceCompile>
     <Link>
       <AdditionalDependencies>SDL3.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <AdditionalLibraryDirectories>external\lib\x86;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>external\lib\$(PlatformTarget);$(SolutionDir)..\external\SDL\VisualC\$(Platform)\$(Configuration)\;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <SubSystem>Windows</SubSystem>
     </Link>
   </ItemDefinitionGroup>
@@ -194,13 +197,14 @@
       <PreprocessorDefinitions>DLL_EXPORT;WIN32;NDEBUG;_WINDOWS;_CRT_SECURE_NO_WARNINGS;TTF_USE_HARFBUZZ=1;FT_PUBLIC_FUNCTION_ATTRIBUTE=;FT_CONFIG_OPTION_USE_HARFBUZZ;FT2_BUILD_LIBRARY;HAVE_FREETYPE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <WarningLevel>Level3</WarningLevel>
+      <AdditionalIncludeDirectories>$(SolutionDir)..\external\SDL\include</AdditionalIncludeDirectories>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ResourceCompile>
     <Link>
       <AdditionalDependencies>SDL3.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <AdditionalLibraryDirectories>external\lib\x64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>external\lib\$(PlatformTarget);$(SolutionDir)..\external\SDL\VisualC\$(Platform)\$(Configuration)\;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <SubSystem>Windows</SubSystem>
     </Link>
   </ItemDefinitionGroup>

--- a/VisualC/SDL_ttf.vcxproj
+++ b/VisualC/SDL_ttf.vcxproj
@@ -117,7 +117,6 @@
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>OldStyle</DebugInformationFormat>
       <EnableEnhancedInstructionSet>StreamingSIMDExtensions</EnableEnhancedInstructionSet>
-      <AdditionalIncludeDirectories>K:\ProjectsMine\SDL_ttf\external\SDL\include</AdditionalIncludeDirectories>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -145,14 +144,13 @@
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>OldStyle</DebugInformationFormat>
-      <AdditionalIncludeDirectories>K:\ProjectsMine\SDL_ttf\external\SDL\include</AdditionalIncludeDirectories>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ResourceCompile>
     <Link>
       <AdditionalDependencies>SDL3.lib;ucrtd.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <AdditionalLibraryDirectories>external\lib\x64;K:\ProjectsMine\SDL_ttf\external\SDL\VisualC\x64\Debug;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>external\lib\x64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>Windows</SubSystem>
     </Link>
@@ -172,7 +170,6 @@
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <WarningLevel>Level3</WarningLevel>
       <EnableEnhancedInstructionSet>StreamingSIMDExtensions</EnableEnhancedInstructionSet>
-      <AdditionalIncludeDirectories>K:\ProjectsMine\SDL_ttf\external\SDL\include</AdditionalIncludeDirectories>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -197,14 +194,13 @@
       <PreprocessorDefinitions>DLL_EXPORT;WIN32;NDEBUG;_WINDOWS;_CRT_SECURE_NO_WARNINGS;TTF_USE_HARFBUZZ=1;FT_PUBLIC_FUNCTION_ATTRIBUTE=;FT_CONFIG_OPTION_USE_HARFBUZZ;FT2_BUILD_LIBRARY;HAVE_FREETYPE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <WarningLevel>Level3</WarningLevel>
-      <AdditionalIncludeDirectories>K:\ProjectsMine\SDL_ttf\external\SDL\include</AdditionalIncludeDirectories>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ResourceCompile>
     <Link>
       <AdditionalDependencies>SDL3.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <AdditionalLibraryDirectories>external\lib\x64;K:\ProjectsMine\SDL_ttf\external\SDL\VisualC\x64\Release;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>external\lib\x64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <SubSystem>Windows</SubSystem>
     </Link>
   </ItemDefinitionGroup>

--- a/VisualC/SDL_ttf.vcxproj.filters
+++ b/VisualC/SDL_ttf.vcxproj.filters
@@ -177,9 +177,6 @@
     <ClCompile Include="..\external\harfbuzz\src\hb-number.cc">
       <Filter>Sources\HarfBuzz</Filter>
     </ClCompile>
-    <ClCompile Include="..\external\harfbuzz\src\hb-ms-feature-ranges.cc">
-      <Filter>Sources\HarfBuzz</Filter>
-    </ClCompile>
     <ClCompile Include="..\external\harfbuzz\src\hb-ot-cff1-table.cc">
       <Filter>Sources\HarfBuzz</Filter>
     </ClCompile>
@@ -205,42 +202,6 @@
       <Filter>Sources\HarfBuzz</Filter>
     </ClCompile>
     <ClCompile Include="..\external\harfbuzz\src\hb-ot-shape.cc">
-      <Filter>Sources\HarfBuzz</Filter>
-    </ClCompile>
-    <ClCompile Include="..\external\harfbuzz\src\hb-ot-shape-complex-arabic.cc">
-      <Filter>Sources\HarfBuzz</Filter>
-    </ClCompile>
-    <ClCompile Include="..\external\harfbuzz\src\hb-ot-shape-complex-default.cc">
-      <Filter>Sources\HarfBuzz</Filter>
-    </ClCompile>
-    <ClCompile Include="..\external\harfbuzz\src\hb-ot-shape-complex-hangul.cc">
-      <Filter>Sources\HarfBuzz</Filter>
-    </ClCompile>
-    <ClCompile Include="..\external\harfbuzz\src\hb-ot-shape-complex-hebrew.cc">
-      <Filter>Sources\HarfBuzz</Filter>
-    </ClCompile>
-    <ClCompile Include="..\external\harfbuzz\src\hb-ot-shape-complex-indic.cc">
-      <Filter>Sources\HarfBuzz</Filter>
-    </ClCompile>
-    <ClCompile Include="..\external\harfbuzz\src\hb-ot-shape-complex-indic-table.cc">
-      <Filter>Sources\HarfBuzz</Filter>
-    </ClCompile>
-    <ClCompile Include="..\external\harfbuzz\src\hb-ot-shape-complex-khmer.cc">
-      <Filter>Sources\HarfBuzz</Filter>
-    </ClCompile>
-    <ClCompile Include="..\external\harfbuzz\src\hb-ot-shape-complex-myanmar.cc">
-      <Filter>Sources\HarfBuzz</Filter>
-    </ClCompile>
-    <ClCompile Include="..\external\harfbuzz\src\hb-ot-shape-complex-syllabic.cc">
-      <Filter>Sources\HarfBuzz</Filter>
-    </ClCompile>
-    <ClCompile Include="..\external\harfbuzz\src\hb-ot-shape-complex-thai.cc">
-      <Filter>Sources\HarfBuzz</Filter>
-    </ClCompile>
-    <ClCompile Include="..\external\harfbuzz\src\hb-ot-shape-complex-use.cc">
-      <Filter>Sources\HarfBuzz</Filter>
-    </ClCompile>
-    <ClCompile Include="..\external\harfbuzz\src\hb-ot-shape-complex-vowel-constraints.cc">
       <Filter>Sources\HarfBuzz</Filter>
     </ClCompile>
     <ClCompile Include="..\external\harfbuzz\src\hb-ot-shape-fallback.cc">
@@ -279,6 +240,50 @@
     <ClCompile Include="..\external\freetype\src\gzip\ftgzip.c">
       <Filter>Sources\FreeType</Filter>
     </ClCompile>
+    <ClCompile Include="..\external\harfbuzz\src\graph\gsubgpos-context.cc" />
+    <ClCompile Include="..\external\harfbuzz\src\hb-buffer-verify.cc" />
+    <ClCompile Include="..\external\harfbuzz\src\hb-cairo-utils.cc" />
+    <ClCompile Include="..\external\harfbuzz\src\hb-cairo.cc" />
+    <ClCompile Include="..\external\harfbuzz\src\hb-coretext.cc" />
+    <ClCompile Include="..\external\harfbuzz\src\hb-directwrite.cc" />
+    <ClCompile Include="..\external\harfbuzz\src\hb-draw.cc" />
+    <ClCompile Include="..\external\harfbuzz\src\hb-face-builder.cc" />
+    <ClCompile Include="..\external\harfbuzz\src\hb-gdi.cc" />
+    <ClCompile Include="..\external\harfbuzz\src\hb-glib.cc" />
+    <ClCompile Include="..\external\harfbuzz\src\hb-gobject-structs.cc" />
+    <ClCompile Include="..\external\harfbuzz\src\hb-graphite2.cc" />
+    <ClCompile Include="..\external\harfbuzz\src\hb-icu.cc" />
+    <ClCompile Include="..\external\harfbuzz\src\hb-map.cc" />
+    <ClCompile Include="..\external\harfbuzz\src\hb-ot-color.cc" />
+    <ClCompile Include="..\external\harfbuzz\src\hb-ot-meta.cc" />
+    <ClCompile Include="..\external\harfbuzz\src\hb-ot-name.cc" />
+    <ClCompile Include="..\external\harfbuzz\src\hb-ot-shaper-arabic.cc" />
+    <ClCompile Include="..\external\harfbuzz\src\hb-ot-shaper-default.cc" />
+    <ClCompile Include="..\external\harfbuzz\src\hb-ot-shaper-hangul.cc" />
+    <ClCompile Include="..\external\harfbuzz\src\hb-ot-shaper-hebrew.cc" />
+    <ClCompile Include="..\external\harfbuzz\src\hb-ot-shaper-indic-table.cc" />
+    <ClCompile Include="..\external\harfbuzz\src\hb-ot-shaper-indic.cc" />
+    <ClCompile Include="..\external\harfbuzz\src\hb-ot-shaper-khmer.cc" />
+    <ClCompile Include="..\external\harfbuzz\src\hb-ot-shaper-myanmar.cc" />
+    <ClCompile Include="..\external\harfbuzz\src\hb-ot-shaper-syllabic.cc" />
+    <ClCompile Include="..\external\harfbuzz\src\hb-ot-shaper-thai.cc" />
+    <ClCompile Include="..\external\harfbuzz\src\hb-ot-shaper-use.cc" />
+    <ClCompile Include="..\external\harfbuzz\src\hb-ot-shaper-vowel-constraints.cc" />
+    <ClCompile Include="..\external\harfbuzz\src\hb-outline.cc" />
+    <ClCompile Include="..\external\harfbuzz\src\hb-paint-extents.cc" />
+    <ClCompile Include="..\external\harfbuzz\src\hb-paint.cc" />
+    <ClCompile Include="..\external\harfbuzz\src\hb-style.cc" />
+    <ClCompile Include="..\external\harfbuzz\src\hb-subset-cff-common.cc" />
+    <ClCompile Include="..\external\harfbuzz\src\hb-subset-cff1.cc" />
+    <ClCompile Include="..\external\harfbuzz\src\hb-subset-cff2.cc" />
+    <ClCompile Include="..\external\harfbuzz\src\hb-subset-input.cc" />
+    <ClCompile Include="..\external\harfbuzz\src\hb-subset-instancer-solver.cc" />
+    <ClCompile Include="..\external\harfbuzz\src\hb-subset-plan.cc" />
+    <ClCompile Include="..\external\harfbuzz\src\hb-subset-repacker.cc" />
+    <ClCompile Include="..\external\harfbuzz\src\hb-subset.cc" />
+    <ClCompile Include="..\external\harfbuzz\src\hb-uniscribe.cc" />
+    <ClCompile Include="..\external\harfbuzz\src\hb-wasm-api.cc" />
+    <ClCompile Include="..\external\harfbuzz\src\hb-wasm-shape.cc" />
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="..\src\version.rc">

--- a/VisualC/SDL_ttf.vcxproj.filters
+++ b/VisualC/SDL_ttf.vcxproj.filters
@@ -177,6 +177,9 @@
     <ClCompile Include="..\external\harfbuzz\src\hb-number.cc">
       <Filter>Sources\HarfBuzz</Filter>
     </ClCompile>
+    <ClCompile Include="..\external\harfbuzz\src\hb-ms-feature-ranges.cc">
+      <Filter>Sources\HarfBuzz</Filter>
+    </ClCompile>
     <ClCompile Include="..\external\harfbuzz\src\hb-ot-cff1-table.cc">
       <Filter>Sources\HarfBuzz</Filter>
     </ClCompile>
@@ -202,6 +205,42 @@
       <Filter>Sources\HarfBuzz</Filter>
     </ClCompile>
     <ClCompile Include="..\external\harfbuzz\src\hb-ot-shape.cc">
+      <Filter>Sources\HarfBuzz</Filter>
+    </ClCompile>
+    <ClCompile Include="..\external\harfbuzz\src\hb-ot-shape-complex-arabic.cc">
+      <Filter>Sources\HarfBuzz</Filter>
+    </ClCompile>
+    <ClCompile Include="..\external\harfbuzz\src\hb-ot-shape-complex-default.cc">
+      <Filter>Sources\HarfBuzz</Filter>
+    </ClCompile>
+    <ClCompile Include="..\external\harfbuzz\src\hb-ot-shape-complex-hangul.cc">
+      <Filter>Sources\HarfBuzz</Filter>
+    </ClCompile>
+    <ClCompile Include="..\external\harfbuzz\src\hb-ot-shape-complex-hebrew.cc">
+      <Filter>Sources\HarfBuzz</Filter>
+    </ClCompile>
+    <ClCompile Include="..\external\harfbuzz\src\hb-ot-shape-complex-indic.cc">
+      <Filter>Sources\HarfBuzz</Filter>
+    </ClCompile>
+    <ClCompile Include="..\external\harfbuzz\src\hb-ot-shape-complex-indic-table.cc">
+      <Filter>Sources\HarfBuzz</Filter>
+    </ClCompile>
+    <ClCompile Include="..\external\harfbuzz\src\hb-ot-shape-complex-khmer.cc">
+      <Filter>Sources\HarfBuzz</Filter>
+    </ClCompile>
+    <ClCompile Include="..\external\harfbuzz\src\hb-ot-shape-complex-myanmar.cc">
+      <Filter>Sources\HarfBuzz</Filter>
+    </ClCompile>
+    <ClCompile Include="..\external\harfbuzz\src\hb-ot-shape-complex-syllabic.cc">
+      <Filter>Sources\HarfBuzz</Filter>
+    </ClCompile>
+    <ClCompile Include="..\external\harfbuzz\src\hb-ot-shape-complex-thai.cc">
+      <Filter>Sources\HarfBuzz</Filter>
+    </ClCompile>
+    <ClCompile Include="..\external\harfbuzz\src\hb-ot-shape-complex-use.cc">
+      <Filter>Sources\HarfBuzz</Filter>
+    </ClCompile>
+    <ClCompile Include="..\external\harfbuzz\src\hb-ot-shape-complex-vowel-constraints.cc">
       <Filter>Sources\HarfBuzz</Filter>
     </ClCompile>
     <ClCompile Include="..\external\harfbuzz\src\hb-ot-shape-fallback.cc">
@@ -240,50 +279,6 @@
     <ClCompile Include="..\external\freetype\src\gzip\ftgzip.c">
       <Filter>Sources\FreeType</Filter>
     </ClCompile>
-    <ClCompile Include="..\external\harfbuzz\src\graph\gsubgpos-context.cc" />
-    <ClCompile Include="..\external\harfbuzz\src\hb-buffer-verify.cc" />
-    <ClCompile Include="..\external\harfbuzz\src\hb-cairo-utils.cc" />
-    <ClCompile Include="..\external\harfbuzz\src\hb-cairo.cc" />
-    <ClCompile Include="..\external\harfbuzz\src\hb-coretext.cc" />
-    <ClCompile Include="..\external\harfbuzz\src\hb-directwrite.cc" />
-    <ClCompile Include="..\external\harfbuzz\src\hb-draw.cc" />
-    <ClCompile Include="..\external\harfbuzz\src\hb-face-builder.cc" />
-    <ClCompile Include="..\external\harfbuzz\src\hb-gdi.cc" />
-    <ClCompile Include="..\external\harfbuzz\src\hb-glib.cc" />
-    <ClCompile Include="..\external\harfbuzz\src\hb-gobject-structs.cc" />
-    <ClCompile Include="..\external\harfbuzz\src\hb-graphite2.cc" />
-    <ClCompile Include="..\external\harfbuzz\src\hb-icu.cc" />
-    <ClCompile Include="..\external\harfbuzz\src\hb-map.cc" />
-    <ClCompile Include="..\external\harfbuzz\src\hb-ot-color.cc" />
-    <ClCompile Include="..\external\harfbuzz\src\hb-ot-meta.cc" />
-    <ClCompile Include="..\external\harfbuzz\src\hb-ot-name.cc" />
-    <ClCompile Include="..\external\harfbuzz\src\hb-ot-shaper-arabic.cc" />
-    <ClCompile Include="..\external\harfbuzz\src\hb-ot-shaper-default.cc" />
-    <ClCompile Include="..\external\harfbuzz\src\hb-ot-shaper-hangul.cc" />
-    <ClCompile Include="..\external\harfbuzz\src\hb-ot-shaper-hebrew.cc" />
-    <ClCompile Include="..\external\harfbuzz\src\hb-ot-shaper-indic-table.cc" />
-    <ClCompile Include="..\external\harfbuzz\src\hb-ot-shaper-indic.cc" />
-    <ClCompile Include="..\external\harfbuzz\src\hb-ot-shaper-khmer.cc" />
-    <ClCompile Include="..\external\harfbuzz\src\hb-ot-shaper-myanmar.cc" />
-    <ClCompile Include="..\external\harfbuzz\src\hb-ot-shaper-syllabic.cc" />
-    <ClCompile Include="..\external\harfbuzz\src\hb-ot-shaper-thai.cc" />
-    <ClCompile Include="..\external\harfbuzz\src\hb-ot-shaper-use.cc" />
-    <ClCompile Include="..\external\harfbuzz\src\hb-ot-shaper-vowel-constraints.cc" />
-    <ClCompile Include="..\external\harfbuzz\src\hb-outline.cc" />
-    <ClCompile Include="..\external\harfbuzz\src\hb-paint-extents.cc" />
-    <ClCompile Include="..\external\harfbuzz\src\hb-paint.cc" />
-    <ClCompile Include="..\external\harfbuzz\src\hb-style.cc" />
-    <ClCompile Include="..\external\harfbuzz\src\hb-subset-cff-common.cc" />
-    <ClCompile Include="..\external\harfbuzz\src\hb-subset-cff1.cc" />
-    <ClCompile Include="..\external\harfbuzz\src\hb-subset-cff2.cc" />
-    <ClCompile Include="..\external\harfbuzz\src\hb-subset-input.cc" />
-    <ClCompile Include="..\external\harfbuzz\src\hb-subset-instancer-solver.cc" />
-    <ClCompile Include="..\external\harfbuzz\src\hb-subset-plan.cc" />
-    <ClCompile Include="..\external\harfbuzz\src\hb-subset-repacker.cc" />
-    <ClCompile Include="..\external\harfbuzz\src\hb-subset.cc" />
-    <ClCompile Include="..\external\harfbuzz\src\hb-uniscribe.cc" />
-    <ClCompile Include="..\external\harfbuzz\src\hb-wasm-api.cc" />
-    <ClCompile Include="..\external\harfbuzz\src\hb-wasm-shape.cc" />
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="..\src\version.rc">

--- a/VisualC/glfont/glfont.vcxproj
+++ b/VisualC/glfont/glfont.vcxproj
@@ -113,6 +113,7 @@
       <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;HAVE_OPENGL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <WarningLevel>Level3</WarningLevel>
+      <AdditionalIncludeDirectories>K:\ProjectsMine\SDL_ttf\external\SDL\include</AdditionalIncludeDirectories>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -143,6 +144,7 @@
       <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;HAVE_OPENGL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <WarningLevel>Level3</WarningLevel>
+      <AdditionalIncludeDirectories>K:\ProjectsMine\SDL_ttf\external\SDL\include</AdditionalIncludeDirectories>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -175,6 +177,7 @@
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>OldStyle</DebugInformationFormat>
+      <AdditionalIncludeDirectories>K:\ProjectsMine\SDL_ttf\external\SDL\include</AdditionalIncludeDirectories>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -208,6 +211,7 @@
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>OldStyle</DebugInformationFormat>
+      <AdditionalIncludeDirectories>K:\ProjectsMine\SDL_ttf\external\SDL\include;K:\ProjectsMine\SDL_ttf\include</AdditionalIncludeDirectories>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -217,6 +221,7 @@
       <AdditionalDependencies>opengl32.lib;SDL3.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>Windows</SubSystem>
+      <AdditionalLibraryDirectories>K:\ProjectsMine\SDL_ttf\external\SDL\VisualC\x64\Debug;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
     <PostBuildEvent>
       <Message>

--- a/VisualC/glfont/glfont.vcxproj
+++ b/VisualC/glfont/glfont.vcxproj
@@ -113,6 +113,7 @@
       <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;HAVE_OPENGL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <WarningLevel>Level3</WarningLevel>
+      <AdditionalIncludeDirectories>$(SolutionDir)..\external\SDL\include;$(SolutionDir)..\include</AdditionalIncludeDirectories>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -120,7 +121,8 @@
     </ResourceCompile>
     <Link>
       <AdditionalDependencies>opengl32.lib;SDL3.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <SubSystem>Windows</SubSystem>
+      <SubSystem>Console</SubSystem>
+      <AdditionalLibraryDirectories>$(SolutionDir)..\external\SDL\VisualC\$(Platform)\$(Configuration)\</AdditionalLibraryDirectories>
     </Link>
     <PostBuildEvent>
       <Message>
@@ -143,6 +145,7 @@
       <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;HAVE_OPENGL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <WarningLevel>Level3</WarningLevel>
+      <AdditionalIncludeDirectories>$(SolutionDir)..\external\SDL\include;$(SolutionDir)..\include</AdditionalIncludeDirectories>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -150,7 +153,8 @@
     </ResourceCompile>
     <Link>
       <AdditionalDependencies>opengl32.lib;SDL3.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <SubSystem>Windows</SubSystem>
+      <SubSystem>Console</SubSystem>
+      <AdditionalLibraryDirectories>$(SolutionDir)..\external\SDL\VisualC\$(Platform)\$(Configuration)\</AdditionalLibraryDirectories>
     </Link>
     <PostBuildEvent>
       <Message>
@@ -175,6 +179,7 @@
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>OldStyle</DebugInformationFormat>
+      <AdditionalIncludeDirectories>$(SolutionDir)..\external\SDL\include;$(SolutionDir)..\include</AdditionalIncludeDirectories>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -183,7 +188,8 @@
     <Link>
       <AdditionalDependencies>opengl32.lib;SDL3.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <SubSystem>Windows</SubSystem>
+      <SubSystem>Console</SubSystem>
+      <AdditionalLibraryDirectories>$(SolutionDir)..\external\SDL\VisualC\$(Platform)\$(Configuration)\</AdditionalLibraryDirectories>
     </Link>
     <PostBuildEvent>
       <Message>
@@ -208,6 +214,7 @@
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>OldStyle</DebugInformationFormat>
+      <AdditionalIncludeDirectories>$(SolutionDir)..\external\SDL\include;$(SolutionDir)..\include</AdditionalIncludeDirectories>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -216,7 +223,8 @@
     <Link>
       <AdditionalDependencies>opengl32.lib;SDL3.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <SubSystem>Windows</SubSystem>
+      <SubSystem>Console</SubSystem>
+      <AdditionalLibraryDirectories>$(SolutionDir)..\external\SDL\VisualC\$(Platform)\$(Configuration)\</AdditionalLibraryDirectories>
     </Link>
     <PostBuildEvent>
       <Message>

--- a/VisualC/glfont/glfont.vcxproj
+++ b/VisualC/glfont/glfont.vcxproj
@@ -113,7 +113,6 @@
       <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;HAVE_OPENGL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <WarningLevel>Level3</WarningLevel>
-      <AdditionalIncludeDirectories>K:\ProjectsMine\SDL_ttf\external\SDL\include</AdditionalIncludeDirectories>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -144,7 +143,6 @@
       <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;HAVE_OPENGL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <WarningLevel>Level3</WarningLevel>
-      <AdditionalIncludeDirectories>K:\ProjectsMine\SDL_ttf\external\SDL\include</AdditionalIncludeDirectories>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -177,7 +175,6 @@
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>OldStyle</DebugInformationFormat>
-      <AdditionalIncludeDirectories>K:\ProjectsMine\SDL_ttf\external\SDL\include</AdditionalIncludeDirectories>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -211,7 +208,6 @@
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>OldStyle</DebugInformationFormat>
-      <AdditionalIncludeDirectories>K:\ProjectsMine\SDL_ttf\external\SDL\include;K:\ProjectsMine\SDL_ttf\include</AdditionalIncludeDirectories>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -221,7 +217,6 @@
       <AdditionalDependencies>opengl32.lib;SDL3.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>Windows</SubSystem>
-      <AdditionalLibraryDirectories>K:\ProjectsMine\SDL_ttf\external\SDL\VisualC\x64\Debug;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
     <PostBuildEvent>
       <Message>

--- a/VisualC/showfont/showfont.vcxproj
+++ b/VisualC/showfont/showfont.vcxproj
@@ -113,6 +113,7 @@
       <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <WarningLevel>Level3</WarningLevel>
+      <AdditionalIncludeDirectories>$(SolutionDir)..\external\SDL\include;$(SolutionDir)..\include</AdditionalIncludeDirectories>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -120,7 +121,8 @@
     </ResourceCompile>
     <Link>
       <AdditionalDependencies>SDL3.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <SubSystem>Windows</SubSystem>
+      <SubSystem>Console</SubSystem>
+      <AdditionalLibraryDirectories>$(SolutionDir)..\external\SDL\VisualC\$(Platform)\$(Configuration)\</AdditionalLibraryDirectories>
     </Link>
     <PostBuildEvent>
       <Message>
@@ -143,6 +145,7 @@
       <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <WarningLevel>Level3</WarningLevel>
+      <AdditionalIncludeDirectories>$(SolutionDir)..\external\SDL\include;$(SolutionDir)..\include</AdditionalIncludeDirectories>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -150,7 +153,8 @@
     </ResourceCompile>
     <Link>
       <AdditionalDependencies>SDL3.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <SubSystem>Windows</SubSystem>
+      <SubSystem>Console</SubSystem>
+      <AdditionalLibraryDirectories>$(SolutionDir)..\external\SDL\VisualC\$(Platform)\$(Configuration)\</AdditionalLibraryDirectories>
     </Link>
     <PostBuildEvent>
       <Message>
@@ -175,6 +179,7 @@
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>OldStyle</DebugInformationFormat>
+      <AdditionalIncludeDirectories>$(SolutionDir)..\external\SDL\include;$(SolutionDir)..\include</AdditionalIncludeDirectories>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -183,7 +188,8 @@
     <Link>
       <AdditionalDependencies>SDL3.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <SubSystem>Windows</SubSystem>
+      <SubSystem>Console</SubSystem>
+      <AdditionalLibraryDirectories>$(SolutionDir)..\external\SDL\VisualC\$(Platform)\$(Configuration)\</AdditionalLibraryDirectories>
     </Link>
     <PostBuildEvent>
       <Message>
@@ -208,6 +214,7 @@
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>OldStyle</DebugInformationFormat>
+      <AdditionalIncludeDirectories>$(SolutionDir)..\external\SDL\include;$(SolutionDir)..\include</AdditionalIncludeDirectories>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -216,7 +223,8 @@
     <Link>
       <AdditionalDependencies>SDL3.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <SubSystem>Windows</SubSystem>
+      <SubSystem>Console</SubSystem>
+      <AdditionalLibraryDirectories>$(SolutionDir)..\external\SDL\VisualC\$(Platform)\$(Configuration)\</AdditionalLibraryDirectories>
     </Link>
     <PostBuildEvent>
       <Message>

--- a/VisualC/showfont/showfont.vcxproj
+++ b/VisualC/showfont/showfont.vcxproj
@@ -113,6 +113,7 @@
       <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <WarningLevel>Level3</WarningLevel>
+      <AdditionalIncludeDirectories>K:\ProjectsMine\SDL_ttf\external\SDL\include</AdditionalIncludeDirectories>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -143,6 +144,7 @@
       <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <WarningLevel>Level3</WarningLevel>
+      <AdditionalIncludeDirectories>K:\ProjectsMine\SDL_ttf\external\SDL\include;K:\ProjectsMine\SDL_ttf\include</AdditionalIncludeDirectories>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -150,7 +152,8 @@
     </ResourceCompile>
     <Link>
       <AdditionalDependencies>SDL3.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <SubSystem>Windows</SubSystem>
+      <SubSystem>Console</SubSystem>
+      <AdditionalLibraryDirectories>K:\ProjectsMine\SDL_ttf\external\SDL\VisualC\x64\Release</AdditionalLibraryDirectories>
     </Link>
     <PostBuildEvent>
       <Message>
@@ -175,6 +178,7 @@
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>OldStyle</DebugInformationFormat>
+      <AdditionalIncludeDirectories>K:\ProjectsMine\SDL_ttf\external\SDL\include</AdditionalIncludeDirectories>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -208,6 +212,7 @@
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>OldStyle</DebugInformationFormat>
+      <AdditionalIncludeDirectories>K:\ProjectsMine\SDL_ttf\external\SDL\include;K:\ProjectsMine\SDL_ttf\include</AdditionalIncludeDirectories>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -216,7 +221,8 @@
     <Link>
       <AdditionalDependencies>SDL3.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <SubSystem>Windows</SubSystem>
+      <SubSystem>Console</SubSystem>
+      <AdditionalLibraryDirectories>K:\ProjectsMine\SDL_ttf\external\SDL\VisualC\x64\Debug;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
     <PostBuildEvent>
       <Message>

--- a/VisualC/showfont/showfont.vcxproj
+++ b/VisualC/showfont/showfont.vcxproj
@@ -113,7 +113,6 @@
       <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <WarningLevel>Level3</WarningLevel>
-      <AdditionalIncludeDirectories>K:\ProjectsMine\SDL_ttf\external\SDL\include</AdditionalIncludeDirectories>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -144,7 +143,6 @@
       <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <WarningLevel>Level3</WarningLevel>
-      <AdditionalIncludeDirectories>K:\ProjectsMine\SDL_ttf\external\SDL\include;K:\ProjectsMine\SDL_ttf\include</AdditionalIncludeDirectories>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -152,8 +150,7 @@
     </ResourceCompile>
     <Link>
       <AdditionalDependencies>SDL3.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <SubSystem>Console</SubSystem>
-      <AdditionalLibraryDirectories>K:\ProjectsMine\SDL_ttf\external\SDL\VisualC\x64\Release</AdditionalLibraryDirectories>
+      <SubSystem>Windows</SubSystem>
     </Link>
     <PostBuildEvent>
       <Message>
@@ -178,7 +175,6 @@
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>OldStyle</DebugInformationFormat>
-      <AdditionalIncludeDirectories>K:\ProjectsMine\SDL_ttf\external\SDL\include</AdditionalIncludeDirectories>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -212,7 +208,6 @@
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>OldStyle</DebugInformationFormat>
-      <AdditionalIncludeDirectories>K:\ProjectsMine\SDL_ttf\external\SDL\include;K:\ProjectsMine\SDL_ttf\include</AdditionalIncludeDirectories>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -221,8 +216,7 @@
     <Link>
       <AdditionalDependencies>SDL3.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <SubSystem>Console</SubSystem>
-      <AdditionalLibraryDirectories>K:\ProjectsMine\SDL_ttf\external\SDL\VisualC\x64\Debug;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <SubSystem>Windows</SubSystem>
     </Link>
     <PostBuildEvent>
       <Message>

--- a/examples/showfont.c
+++ b/examples/showfont.c
@@ -148,7 +148,7 @@ int main(int argc, char *argv[])
     int dump;
     int winWidth = WIDTH;
     int winHeight = HEIGHT;
-    int wrapWidth = WIDTH - 10;
+    int wrapWidth = WIDTH;
     enum
     {
         RENDER_LATIN1,
@@ -453,7 +453,7 @@ int main(int argc, char *argv[])
             draw_scene(renderer, &scene);
             break;
 
-            // case SDL_EVENT_KEY_DOWN:
+        case SDL_EVENT_KEY_DOWN:
         case SDL_EVENT_QUIT:
             done = 1;
             break;

--- a/examples/showfont.c
+++ b/examples/showfont.c
@@ -47,13 +47,13 @@ typedef enum
 
 typedef struct
 {
-    SDL_Texture *caption;
+    SDL_Texture* caption;
     SDL_FRect captionRect;
-    SDL_Texture *message;
+    SDL_Texture* message;
     SDL_FRect messageRect;
 } Scene;
 
-static void draw_scene(SDL_Renderer *renderer, Scene *scene)
+static void draw_scene(SDL_Renderer* renderer, Scene* scene)
 {
     /* Clear the background to background color */
     SDL_SetRenderDrawColor(renderer, 0xFF, 0xFF, 0xFF, 0xFF);
@@ -71,10 +71,11 @@ static void cleanup(int exitcode)
     exit(exitcode);
 }
 
-int load_file(char **bufferAddr, const char *pathName)
+int load_file(char** bufferAddr, const char* pathName)
 {
-    FILE *file = fopen(pathName, "rb");
-    if (file == NULL) {
+    FILE* file = fopen(pathName, "rb");
+    if (file == NULL)
+    {
         perror("Error opening file");
         return 1;
     }
@@ -82,7 +83,8 @@ int load_file(char **bufferAddr, const char *pathName)
     fseek(file, 0, SEEK_END);
     long file_size = ftell(file);
 
-    if (file_size == 0) {
+    if (file_size == 0)
+    {
         fclose(file);
         return 0;
     }
@@ -90,22 +92,26 @@ int load_file(char **bufferAddr, const char *pathName)
     fseek(file, 0, SEEK_SET);
 
     *bufferAddr = malloc(file_size + 1);
-    char *buffer = *bufferAddr;
+    char* buffer = *bufferAddr;
     memset(buffer, 0, file_size + 1);
 
     size_t bytesRead = fread(buffer, 1, file_size, file);
-    if (bytesRead == 0) {
+    if (bytesRead == 0)
+    {
         perror("Error reading file");
         fclose(file);
         return 1;
     }
 
-    if (fread(buffer, file_size, 1, file) != 0) {
+    if (fread(buffer, file_size, 1, file) != 0)
+    {
         return 1;
     }
 
-    for (int i = 0; i < file_size; ++i) {
-        if (iscntrl(buffer[i])) {
+    for (int i = 0; i < file_size; ++i)
+    {
+        if (iscntrl(buffer[i]))
+        {
             buffer[i] = 32;
         }
     }
@@ -115,20 +121,20 @@ int load_file(char **bufferAddr, const char *pathName)
     return 0;
 }
 
-int main(int argc, char *argv[])
+int main(int argc, char* argv[])
 {
-    char *argv0 = argv[0];
-    SDL_Window *window;
-    SDL_Renderer *renderer;
-    TTF_Font *font;
-    SDL_Surface *text = NULL;
+    char* argv0 = argv[0];
+    SDL_Window* window;
+    SDL_Renderer* renderer;
+    TTF_Font* font;
+    SDL_Surface* text = NULL;
     Scene scene;
     int ptsize;
     int i, done;
     SDL_Color white = { 0xFF, 0xFF, 0xFF, 0 };
     SDL_Color black = { 0x00, 0x00, 0x00, 0 };
-    SDL_Color *forecol;
-    SDL_Color *backcol;
+    SDL_Color* forecol;
+    SDL_Color* backcol;
     SDL_Event event;
     TextRenderMethod rendermethod;
     int renderstyle;
@@ -146,7 +152,7 @@ int main(int argc, char *argv[])
         RENDER_UTF8,
         RENDER_UNICODE
     } rendertype;
-    char *message, *fileMessage, string[128];
+    char* message, * fileMessage, string[128];
     fileMessage = NULL;
 
     /* Look for special execution mode */
@@ -162,46 +168,79 @@ int main(int argc, char *argv[])
     forecol = &black;
     backcol = &white;
 
-    if (argc == 1) {
+    if (argc == 1)
+    {
         SDL_Log(TTF_SHOWFONT_USAGE, argv0);
         return (1);
     }
 
-    for (i = 1; argv[i] && argv[i][0] == '-'; ++i) {
-        if (SDL_strcmp(argv[i], "-solid") == 0) {
+    for (i = 1; argv[i] && argv[i][0] == '-'; ++i)
+    {
+        if (SDL_strcmp(argv[i], "-solid") == 0)
+        {
             rendermethod = TextRenderSolid;
-        } else if (SDL_strcmp(argv[i], "-shaded") == 0) {
+        }
+        else if (SDL_strcmp(argv[i], "-shaded") == 0)
+        {
             rendermethod = TextRenderShaded;
-        } else if (SDL_strcmp(argv[i], "-blended") == 0) {
+        }
+        else if (SDL_strcmp(argv[i], "-blended") == 0)
+        {
             rendermethod = TextRenderBlended;
-        } else if (SDL_strcmp(argv[i], "-b") == 0) {
+        }
+        else if (SDL_strcmp(argv[i], "-b") == 0)
+        {
             renderstyle |= TTF_STYLE_BOLD;
-        } else if (SDL_strcmp(argv[i], "-i") == 0) {
+        }
+        else if (SDL_strcmp(argv[i], "-i") == 0)
+        {
             renderstyle |= TTF_STYLE_ITALIC;
-        } else if (SDL_strcmp(argv[i], "-u") == 0) {
+        }
+        else if (SDL_strcmp(argv[i], "-u") == 0)
+        {
             renderstyle |= TTF_STYLE_UNDERLINE;
-        } else if (SDL_strcmp(argv[i], "-s") == 0) {
+        }
+        else if (SDL_strcmp(argv[i], "-s") == 0)
+        {
             renderstyle |= TTF_STYLE_STRIKETHROUGH;
-        } else if (SDL_strcmp(argv[i], "-outline") == 0) {
-            if (SDL_sscanf(argv[++i], "%d", &outline) != 1) {
+        }
+        else if (SDL_strcmp(argv[i], "-outline") == 0)
+        {
+            if (SDL_sscanf(argv[++i], "%d", &outline) != 1)
+            {
                 SDL_Log(TTF_SHOWFONT_USAGE, argv0);
                 return (1);
             }
-        } else if (SDL_strcmp(argv[i], "-hintlight") == 0) {
+        }
+        else if (SDL_strcmp(argv[i], "-hintlight") == 0)
+        {
             hinting = TTF_HINTING_LIGHT;
-        } else if (SDL_strcmp(argv[i], "-hintmono") == 0) {
+        }
+        else if (SDL_strcmp(argv[i], "-hintmono") == 0)
+        {
             hinting = TTF_HINTING_MONO;
-        } else if (SDL_strcmp(argv[i], "-hintnone") == 0) {
+        }
+        else if (SDL_strcmp(argv[i], "-hintnone") == 0)
+        {
             hinting = TTF_HINTING_NONE;
-        } else if (SDL_strcmp(argv[i], "-nokerning") == 0) {
+        }
+        else if (SDL_strcmp(argv[i], "-nokerning") == 0)
+        {
             kerning = 0;
-        } else if (SDL_strcmp(argv[i], "-wrap") == 0) {
+        }
+        else if (SDL_strcmp(argv[i], "-wrap") == 0)
+        {
             wrap = 1;
-        } else if (SDL_strcmp(argv[i], "-dump") == 0) {
+        }
+        else if (SDL_strcmp(argv[i], "-dump") == 0)
+        {
             dump = 1;
-        } else if (SDL_strcmp(argv[i], "-fgcol") == 0) {
+        }
+        else if (SDL_strcmp(argv[i], "-fgcol") == 0)
+        {
             int r, g, b, a = 0xFF;
-            if (SDL_sscanf(argv[++i], "%d,%d,%d,%d", &r, &g, &b, &a) < 3) {
+            if (SDL_sscanf(argv[++i], "%d,%d,%d,%d", &r, &g, &b, &a) < 3)
+            {
                 SDL_Log(TTF_SHOWFONT_USAGE, argv0);
                 return (1);
             }
@@ -209,9 +248,12 @@ int main(int argc, char *argv[])
             forecol->g = (Uint8)g;
             forecol->b = (Uint8)b;
             forecol->a = (Uint8)a;
-        } else if (SDL_strcmp(argv[i], "-bgcol") == 0) {
+        }
+        else if (SDL_strcmp(argv[i], "-bgcol") == 0)
+        {
             int r, g, b, a = 0xFF;
-            if (SDL_sscanf(argv[++i], "%d,%d,%d,%d", &r, &g, &b, &a) < 3) {
+            if (SDL_sscanf(argv[++i], "%d,%d,%d,%d", &r, &g, &b, &a) < 3)
+            {
                 SDL_Log(TTF_SHOWFONT_USAGE, argv0);
                 return (1);
             }
@@ -219,17 +261,24 @@ int main(int argc, char *argv[])
             backcol->g = (Uint8)g;
             backcol->b = (Uint8)b;
             backcol->a = (Uint8)a;
-        } else if (SDL_strcmp(argv[i], "-utf8txtfile") == 0) {
+        }
+        else if (SDL_strcmp(argv[i], "-utf8txtfile") == 0)
+        {
             load_file(&fileMessage, argv[++i]);
             rendertype = RENDER_UTF8;
             wrap = 1;
-        } else if (SDL_strcmp(argv[i], "-windowsize") == 0) {
-            if (SDL_sscanf(argv[++i], "%d,%d", &winWidth, &winHeight) < 2) {
+        }
+        else if (SDL_strcmp(argv[i], "-windowsize") == 0)
+        {
+            if (SDL_sscanf(argv[++i], "%d,%d", &winWidth, &winHeight) < 2)
+            {
                 SDL_Log(TTF_SHOWFONT_USAGE, argv0);
                 return (1);
             }
             wrapWidth = winWidth - 10;
-        } else {
+        }
+        else
+        {
             SDL_Log(TTF_SHOWFONT_USAGE, argv0);
             return (1);
         }
@@ -238,13 +287,15 @@ int main(int argc, char *argv[])
     argc -= i;
 
     /* Check usage */
-    if (!argv[0]) {
+    if (!argv[0])
+    {
         SDL_Log(TTF_SHOWFONT_USAGE, argv0);
         return (1);
     }
 
     /* Initialize the TTF library */
-    if (TTF_Init() < 0) {
+    if (TTF_Init() < 0)
+    {
         SDL_Log("Couldn't initialize TTF: %s\n", SDL_GetError());
         SDL_Quit();
         return (2);
@@ -252,19 +303,24 @@ int main(int argc, char *argv[])
 
     /* Open the font file with the requested point size */
     ptsize = 0;
-    if (argc > 1) {
+    if (argc > 1)
+    {
         ptsize = SDL_atoi(argv[1]);
     }
-    if (ptsize == 0) {
+    if (ptsize == 0)
+    {
         i = 2;
         ptsize = DEFAULT_PTSIZE;
-    } else {
+    }
+    else
+    {
         i = 3;
     }
     font = TTF_OpenFont(argv[0], ptsize);
-    if (font == NULL) {
+    if (font == NULL)
+    {
         SDL_Log("Couldn't load %d pt font from %s: %s\n",
-                ptsize, argv[0], SDL_GetError());
+            ptsize, argv[0], SDL_GetError());
         cleanup(2);
     }
     TTF_SetFontStyle(font, renderstyle);
@@ -272,13 +328,16 @@ int main(int argc, char *argv[])
     TTF_SetFontKerning(font, kerning);
     TTF_SetFontHinting(font, hinting);
 
-    if (dump) {
-        for (i = 48; i < 123; i++) {
-            SDL_Surface *glyph = NULL;
+    if (dump)
+    {
+        for (i = 48; i < 123; i++)
+        {
+            SDL_Surface* glyph = NULL;
 
             glyph = TTF_RenderGlyph_Shaded(font, i, *forecol, *backcol);
 
-            if (glyph) {
+            if (glyph)
+            {
                 char outname[64];
                 SDL_snprintf(outname, sizeof(outname), "glyph-%d.bmp", i);
                 SDL_SaveBMP(glyph, outname);
@@ -288,18 +347,21 @@ int main(int argc, char *argv[])
     }
 
     /* Create a window */
-    if (SDL_CreateWindowAndRenderer(winWidth, winHeight, 0, &window, &renderer) < 0) {
+    if (SDL_CreateWindowAndRenderer(winWidth, winHeight, 0, &window, &renderer) < 0)
+    {
         SDL_Log("SDL_CreateWindowAndRenderer() failed: %s\n", SDL_GetError());
         cleanup(2);
     }
 
-    if (window) {
+    if (window)
+    {
         SDL_SetWindowTitle(window, "Show Font");
     }
 
     /* Show which font file we're looking at */
     SDL_snprintf(string, sizeof(string), "Font file: %s", argv[0]); /* possible overflow */
-    switch (rendermethod) {
+    switch (rendermethod)
+    {
     case TextRenderSolid:
         text = TTF_RenderText_Solid(font, string, *forecol);
         break;
@@ -310,7 +372,8 @@ int main(int argc, char *argv[])
         text = TTF_RenderText_Blended(font, string, *forecol);
         break;
     }
-    if (text != NULL) {
+    if (text != NULL)
+    {
         scene.captionRect.x = 4.0f;
         scene.captionRect.y = 4.0f;
         scene.captionRect.w = (float)text->w;
@@ -320,37 +383,54 @@ int main(int argc, char *argv[])
     }
 
     /* Render and center the message */
-    if (fileMessage != NULL) {
+    if (fileMessage != NULL)
+    {
         message = fileMessage;
-    } else {
-        if (argc > 2) {
+    }
+    else
+    {
+        if (argc > 2)
+        {
             message = argv[2];
-        } else {
+        }
+        else
+        {
             message = DEFAULT_TEXT;
         }
     }
 
-    switch (rendertype) {
+    switch (rendertype)
+    {
     case RENDER_LATIN1:
-        switch (rendermethod) {
+        switch (rendermethod)
+        {
         case TextRenderSolid:
-            if (wrap) {
+            if (wrap)
+            {
                 text = TTF_RenderText_Solid_Wrapped(font, message, *forecol, wrapWidth);
-            } else {
+            }
+            else
+            {
                 text = TTF_RenderText_Solid(font, message, *forecol);
             }
             break;
         case TextRenderShaded:
-            if (wrap) {
+            if (wrap)
+            {
                 text = TTF_RenderText_Shaded_Wrapped(font, message, *forecol, *backcol, wrapWidth);
-            } else {
+            }
+            else
+            {
                 text = TTF_RenderText_Shaded(font, message, *forecol, *backcol);
             }
             break;
         case TextRenderBlended:
-            if (wrap) {
+            if (wrap)
+            {
                 text = TTF_RenderText_Blended_Wrapped(font, message, *forecol, wrapWidth);
-            } else {
+            }
+            else
+            {
                 text = TTF_RenderText_Blended(font, message, *forecol);
             }
             break;
@@ -358,25 +438,35 @@ int main(int argc, char *argv[])
         break;
 
     case RENDER_UTF8:
-        switch (rendermethod) {
+        switch (rendermethod)
+        {
         case TextRenderSolid:
-            if (wrap) {
+            if (wrap)
+            {
                 text = TTF_RenderUTF8_Solid_Wrapped(font, message, *forecol, wrapWidth);
-            } else {
+            }
+            else
+            {
                 text = TTF_RenderUTF8_Solid(font, message, *forecol);
             }
             break;
         case TextRenderShaded:
-            if (wrap) {
+            if (wrap)
+            {
                 text = TTF_RenderUTF8_Shaded_Wrapped(font, message, *forecol, *backcol, wrapWidth);
-            } else {
+            }
+            else
+            {
                 text = TTF_RenderUTF8_Shaded(font, message, *forecol, *backcol);
             }
             break;
         case TextRenderBlended:
-            if (wrap) {
+            if (wrap)
+            {
                 text = TTF_RenderUTF8_Blended_Wrapped(font, message, *forecol, wrapWidth);
-            } else {
+            }
+            else
+            {
                 text = TTF_RenderUTF8_Blended(font, message, *forecol);
             }
             break;
@@ -385,26 +475,36 @@ int main(int argc, char *argv[])
 
     case RENDER_UNICODE:
     {
-        Uint16 *unicode_text = SDL_iconv_utf8_ucs2(message);
-        switch (rendermethod) {
+        Uint16* unicode_text = SDL_iconv_utf8_ucs2(message);
+        switch (rendermethod)
+        {
         case TextRenderSolid:
-            if (wrap) {
+            if (wrap)
+            {
                 text = TTF_RenderUNICODE_Solid_Wrapped(font, unicode_text, *forecol, wrapWidth);
-            } else {
+            }
+            else
+            {
                 text = TTF_RenderUNICODE_Solid(font, unicode_text, *forecol);
             }
             break;
         case TextRenderShaded:
-            if (wrap) {
+            if (wrap)
+            {
                 text = TTF_RenderUNICODE_Shaded_Wrapped(font, unicode_text, *forecol, *backcol, wrapWidth);
-            } else {
+            }
+            else
+            {
                 text = TTF_RenderUNICODE_Shaded(font, unicode_text, *forecol, *backcol);
             }
             break;
         case TextRenderBlended:
-            if (wrap) {
+            if (wrap)
+            {
                 text = TTF_RenderUNICODE_Blended_Wrapped(font, unicode_text, *forecol, wrapWidth);
-            } else {
+            }
+            else
+            {
                 text = TTF_RenderUNICODE_Blended(font, unicode_text, *forecol);
             }
             break;
@@ -412,7 +512,8 @@ int main(int argc, char *argv[])
         SDL_free(unicode_text);
     } break;
     }
-    if (text == NULL) {
+    if (text == NULL)
+    {
         SDL_Log("Couldn't render text: %s\n", SDL_GetError());
         TTF_CloseFont(font);
         cleanup(2);
@@ -423,19 +524,22 @@ int main(int argc, char *argv[])
     scene.messageRect.h = (float)text->h;
     scene.message = SDL_CreateTextureFromSurface(renderer, text);
     SDL_Log("Font is generally %d big, and string is %d big\n",
-            TTF_FontHeight(font), text->h);
+        TTF_FontHeight(font), text->h);
 
     draw_scene(renderer, &scene);
 
     /* Wait for a keystroke, and blit text on mouse press */
     done = 0;
-    while (!done) {
-        if (!SDL_WaitEvent(&event)) {
+    while (!done)
+    {
+        if (!SDL_WaitEvent(&event))
+        {
             // SDL_Log("SDL_PullEvent() error: %s\n", SDL_GetError());
             //  done = 1;
             continue;
         }
-        switch (event.type) {
+        switch (event.type)
+        {
         case SDL_EVENT_MOUSE_BUTTON_DOWN:
             scene.messageRect.x = (float)(event.button.x - text->w / 2);
             scene.messageRect.y = (float)(event.button.y - text->h / 2);
@@ -444,7 +548,7 @@ int main(int argc, char *argv[])
             draw_scene(renderer, &scene);
             break;
 
-        // case SDL_EVENT_KEY_DOWN:
+            // case SDL_EVENT_KEY_DOWN:
         case SDL_EVENT_QUIT:
             done = 1;
             break;
@@ -458,7 +562,8 @@ int main(int argc, char *argv[])
     SDL_DestroyTexture(scene.message);
     cleanup(0);
 
-    if (fileMessage != NULL) {
+    if (fileMessage != NULL)
+    {
         free(fileMessage);
     }
 

--- a/examples/showfont.c
+++ b/examples/showfont.c
@@ -342,7 +342,7 @@ int main(int argc, char *argv[])
 
     if (window)
     {
-        SDL_SetWindowTitle(window, "Show Font");
+        SDL_SetWindowTitle(window, argv0);
     }
 
     /* Show which font file we're looking at */

--- a/examples/showfont.c
+++ b/examples/showfont.c
@@ -36,7 +36,13 @@
 #define HEIGHT         800
 
 #define TTF_SHOWFONT_USAGE \
-    "Usage: %s [-windowsize w,h] [-solid] [-shaded] [-blended] [-wrapped] [-b] [-i] [-u] [-s] [-outline size] [-hintlight|-hintmono|-hintnone] [-nokerning] [-wrap] [-fgcol r,g,b,a] [-bgcol r,g,b,a] [-utf8txtfile pathName] <font>.ttf [ptsize] [text]\n"
+    "Usage:\n"             \
+    "    %s [-windowsize w,h] [-solid] [-shaded] [-blended] [-wrapped] [-b] [-i] [-u] [-s] [-outline size] [-hintlight | -hintmono | -hintnone] [-nokerning] [-wrap] [-fgcol r,g,b,a] [-bgcol r,g,b,a] [-utf8txtfile pathName] <font>.ttf [ptsize] [text] \n"
+
+#define TTF_SHOWFONT_USAGE_WITH_EXAMPLE                                                                                    \
+    TTF_SHOWFONT_USAGE##"Example:\n"                                                                                       \
+                        "    %s -b -wrap -fgcol 255,0,255,255 -bgcol 64,64,64,255 NotoSansSC.ttf 32 \"This is a test.\"\n" \
+                        "    %s -windowsize 1920,1200 -utf8txtfile content.txt NotoSansSC.ttf"
 
 typedef enum
 {
@@ -47,13 +53,13 @@ typedef enum
 
 typedef struct
 {
-    SDL_Texture* caption;
+    SDL_Texture *caption;
     SDL_FRect captionRect;
-    SDL_Texture* message;
+    SDL_Texture *message;
     SDL_FRect messageRect;
 } Scene;
 
-static void draw_scene(SDL_Renderer* renderer, Scene* scene)
+static void draw_scene(SDL_Renderer *renderer, Scene *scene)
 {
     /* Clear the background to background color */
     SDL_SetRenderDrawColor(renderer, 0xFF, 0xFF, 0xFF, 0xFF);
@@ -71,9 +77,9 @@ static void cleanup(int exitcode)
     exit(exitcode);
 }
 
-int load_file(char** bufferAddr, const char* pathName)
+int load_file(char **bufferAddr, const char *pathName)
 {
-    FILE* file = fopen(pathName, "rb");
+    FILE *file = fopen(pathName, "rb");
     if (file == NULL)
     {
         perror("Error opening file");
@@ -92,7 +98,7 @@ int load_file(char** bufferAddr, const char* pathName)
     fseek(file, 0, SEEK_SET);
 
     *bufferAddr = malloc(file_size + 1);
-    char* buffer = *bufferAddr;
+    char *buffer = *bufferAddr;
     memset(buffer, 0, file_size + 1);
 
     size_t bytesRead = fread(buffer, 1, file_size, file);
@@ -121,20 +127,20 @@ int load_file(char** bufferAddr, const char* pathName)
     return 0;
 }
 
-int main(int argc, char* argv[])
+int main(int argc, char *argv[])
 {
-    char* argv0 = argv[0];
-    SDL_Window* window;
-    SDL_Renderer* renderer;
-    TTF_Font* font;
-    SDL_Surface* text = NULL;
+    char *argv0 = argv[0];
+    SDL_Window *window;
+    SDL_Renderer *renderer;
+    TTF_Font *font;
+    SDL_Surface *text = NULL;
     Scene scene;
     int ptsize;
     int i, done;
     SDL_Color white = { 0xFF, 0xFF, 0xFF, 0 };
     SDL_Color black = { 0x00, 0x00, 0x00, 0 };
-    SDL_Color* forecol;
-    SDL_Color* backcol;
+    SDL_Color *forecol;
+    SDL_Color *backcol;
     SDL_Event event;
     TextRenderMethod rendermethod;
     int renderstyle;
@@ -152,7 +158,7 @@ int main(int argc, char* argv[])
         RENDER_UTF8,
         RENDER_UNICODE
     } rendertype;
-    char* message, * fileMessage, string[128];
+    char *message, *fileMessage, string[128];
     fileMessage = NULL;
 
     /* Look for special execution mode */
@@ -170,7 +176,7 @@ int main(int argc, char* argv[])
 
     if (argc == 1)
     {
-        SDL_Log(TTF_SHOWFONT_USAGE, argv0);
+        printf(TTF_SHOWFONT_USAGE_WITH_EXAMPLE, argv0, argv0, argv0);
         return (1);
     }
 
@@ -179,64 +185,50 @@ int main(int argc, char* argv[])
         if (SDL_strcmp(argv[i], "-solid") == 0)
         {
             rendermethod = TextRenderSolid;
-        }
-        else if (SDL_strcmp(argv[i], "-shaded") == 0)
+        } else if (SDL_strcmp(argv[i], "-shaded") == 0)
         {
             rendermethod = TextRenderShaded;
-        }
-        else if (SDL_strcmp(argv[i], "-blended") == 0)
+        } else if (SDL_strcmp(argv[i], "-blended") == 0)
         {
             rendermethod = TextRenderBlended;
-        }
-        else if (SDL_strcmp(argv[i], "-b") == 0)
+        } else if (SDL_strcmp(argv[i], "-b") == 0)
         {
             renderstyle |= TTF_STYLE_BOLD;
-        }
-        else if (SDL_strcmp(argv[i], "-i") == 0)
+        } else if (SDL_strcmp(argv[i], "-i") == 0)
         {
             renderstyle |= TTF_STYLE_ITALIC;
-        }
-        else if (SDL_strcmp(argv[i], "-u") == 0)
+        } else if (SDL_strcmp(argv[i], "-u") == 0)
         {
             renderstyle |= TTF_STYLE_UNDERLINE;
-        }
-        else if (SDL_strcmp(argv[i], "-s") == 0)
+        } else if (SDL_strcmp(argv[i], "-s") == 0)
         {
             renderstyle |= TTF_STYLE_STRIKETHROUGH;
-        }
-        else if (SDL_strcmp(argv[i], "-outline") == 0)
+        } else if (SDL_strcmp(argv[i], "-outline") == 0)
         {
             if (SDL_sscanf(argv[++i], "%d", &outline) != 1)
             {
                 SDL_Log(TTF_SHOWFONT_USAGE, argv0);
                 return (1);
             }
-        }
-        else if (SDL_strcmp(argv[i], "-hintlight") == 0)
+        } else if (SDL_strcmp(argv[i], "-hintlight") == 0)
         {
             hinting = TTF_HINTING_LIGHT;
-        }
-        else if (SDL_strcmp(argv[i], "-hintmono") == 0)
+        } else if (SDL_strcmp(argv[i], "-hintmono") == 0)
         {
             hinting = TTF_HINTING_MONO;
-        }
-        else if (SDL_strcmp(argv[i], "-hintnone") == 0)
+        } else if (SDL_strcmp(argv[i], "-hintnone") == 0)
         {
             hinting = TTF_HINTING_NONE;
-        }
-        else if (SDL_strcmp(argv[i], "-nokerning") == 0)
+        } else if (SDL_strcmp(argv[i], "-nokerning") == 0)
         {
             kerning = 0;
-        }
-        else if (SDL_strcmp(argv[i], "-wrap") == 0)
+        } else if (SDL_strcmp(argv[i], "-wrap") == 0)
         {
             wrap = 1;
-        }
-        else if (SDL_strcmp(argv[i], "-dump") == 0)
+        } else if (SDL_strcmp(argv[i], "-dump") == 0)
         {
             dump = 1;
-        }
-        else if (SDL_strcmp(argv[i], "-fgcol") == 0)
+        } else if (SDL_strcmp(argv[i], "-fgcol") == 0)
         {
             int r, g, b, a = 0xFF;
             if (SDL_sscanf(argv[++i], "%d,%d,%d,%d", &r, &g, &b, &a) < 3)
@@ -248,8 +240,7 @@ int main(int argc, char* argv[])
             forecol->g = (Uint8)g;
             forecol->b = (Uint8)b;
             forecol->a = (Uint8)a;
-        }
-        else if (SDL_strcmp(argv[i], "-bgcol") == 0)
+        } else if (SDL_strcmp(argv[i], "-bgcol") == 0)
         {
             int r, g, b, a = 0xFF;
             if (SDL_sscanf(argv[++i], "%d,%d,%d,%d", &r, &g, &b, &a) < 3)
@@ -261,14 +252,12 @@ int main(int argc, char* argv[])
             backcol->g = (Uint8)g;
             backcol->b = (Uint8)b;
             backcol->a = (Uint8)a;
-        }
-        else if (SDL_strcmp(argv[i], "-utf8txtfile") == 0)
+        } else if (SDL_strcmp(argv[i], "-utf8txtfile") == 0)
         {
             load_file(&fileMessage, argv[++i]);
             rendertype = RENDER_UTF8;
             wrap = 1;
-        }
-        else if (SDL_strcmp(argv[i], "-windowsize") == 0)
+        } else if (SDL_strcmp(argv[i], "-windowsize") == 0)
         {
             if (SDL_sscanf(argv[++i], "%d,%d", &winWidth, &winHeight) < 2)
             {
@@ -276,8 +265,7 @@ int main(int argc, char* argv[])
                 return (1);
             }
             wrapWidth = winWidth - 10;
-        }
-        else
+        } else
         {
             SDL_Log(TTF_SHOWFONT_USAGE, argv0);
             return (1);
@@ -311,8 +299,7 @@ int main(int argc, char* argv[])
     {
         i = 2;
         ptsize = DEFAULT_PTSIZE;
-    }
-    else
+    } else
     {
         i = 3;
     }
@@ -320,7 +307,7 @@ int main(int argc, char* argv[])
     if (font == NULL)
     {
         SDL_Log("Couldn't load %d pt font from %s: %s\n",
-            ptsize, argv[0], SDL_GetError());
+                ptsize, argv[0], SDL_GetError());
         cleanup(2);
     }
     TTF_SetFontStyle(font, renderstyle);
@@ -332,7 +319,7 @@ int main(int argc, char* argv[])
     {
         for (i = 48; i < 123; i++)
         {
-            SDL_Surface* glyph = NULL;
+            SDL_Surface *glyph = NULL;
 
             glyph = TTF_RenderGlyph_Shaded(font, i, *forecol, *backcol);
 
@@ -386,14 +373,12 @@ int main(int argc, char* argv[])
     if (fileMessage != NULL)
     {
         message = fileMessage;
-    }
-    else
+    } else
     {
         if (argc > 2)
         {
             message = argv[2];
-        }
-        else
+        } else
         {
             message = DEFAULT_TEXT;
         }
@@ -408,8 +393,7 @@ int main(int argc, char* argv[])
             if (wrap)
             {
                 text = TTF_RenderText_Solid_Wrapped(font, message, *forecol, wrapWidth);
-            }
-            else
+            } else
             {
                 text = TTF_RenderText_Solid(font, message, *forecol);
             }
@@ -418,8 +402,7 @@ int main(int argc, char* argv[])
             if (wrap)
             {
                 text = TTF_RenderText_Shaded_Wrapped(font, message, *forecol, *backcol, wrapWidth);
-            }
-            else
+            } else
             {
                 text = TTF_RenderText_Shaded(font, message, *forecol, *backcol);
             }
@@ -428,8 +411,7 @@ int main(int argc, char* argv[])
             if (wrap)
             {
                 text = TTF_RenderText_Blended_Wrapped(font, message, *forecol, wrapWidth);
-            }
-            else
+            } else
             {
                 text = TTF_RenderText_Blended(font, message, *forecol);
             }
@@ -444,8 +426,7 @@ int main(int argc, char* argv[])
             if (wrap)
             {
                 text = TTF_RenderUTF8_Solid_Wrapped(font, message, *forecol, wrapWidth);
-            }
-            else
+            } else
             {
                 text = TTF_RenderUTF8_Solid(font, message, *forecol);
             }
@@ -454,8 +435,7 @@ int main(int argc, char* argv[])
             if (wrap)
             {
                 text = TTF_RenderUTF8_Shaded_Wrapped(font, message, *forecol, *backcol, wrapWidth);
-            }
-            else
+            } else
             {
                 text = TTF_RenderUTF8_Shaded(font, message, *forecol, *backcol);
             }
@@ -464,8 +444,7 @@ int main(int argc, char* argv[])
             if (wrap)
             {
                 text = TTF_RenderUTF8_Blended_Wrapped(font, message, *forecol, wrapWidth);
-            }
-            else
+            } else
             {
                 text = TTF_RenderUTF8_Blended(font, message, *forecol);
             }
@@ -475,15 +454,14 @@ int main(int argc, char* argv[])
 
     case RENDER_UNICODE:
     {
-        Uint16* unicode_text = SDL_iconv_utf8_ucs2(message);
+        Uint16 *unicode_text = SDL_iconv_utf8_ucs2(message);
         switch (rendermethod)
         {
         case TextRenderSolid:
             if (wrap)
             {
                 text = TTF_RenderUNICODE_Solid_Wrapped(font, unicode_text, *forecol, wrapWidth);
-            }
-            else
+            } else
             {
                 text = TTF_RenderUNICODE_Solid(font, unicode_text, *forecol);
             }
@@ -492,8 +470,7 @@ int main(int argc, char* argv[])
             if (wrap)
             {
                 text = TTF_RenderUNICODE_Shaded_Wrapped(font, unicode_text, *forecol, *backcol, wrapWidth);
-            }
-            else
+            } else
             {
                 text = TTF_RenderUNICODE_Shaded(font, unicode_text, *forecol, *backcol);
             }
@@ -502,15 +479,15 @@ int main(int argc, char* argv[])
             if (wrap)
             {
                 text = TTF_RenderUNICODE_Blended_Wrapped(font, unicode_text, *forecol, wrapWidth);
-            }
-            else
+            } else
             {
                 text = TTF_RenderUNICODE_Blended(font, unicode_text, *forecol);
             }
             break;
         }
         SDL_free(unicode_text);
-    } break;
+    }
+    break;
     }
     if (text == NULL)
     {
@@ -524,7 +501,7 @@ int main(int argc, char* argv[])
     scene.messageRect.h = (float)text->h;
     scene.message = SDL_CreateTextureFromSurface(renderer, text);
     SDL_Log("Font is generally %d big, and string is %d big\n",
-        TTF_FontHeight(font), text->h);
+            TTF_FontHeight(font), text->h);
 
     draw_scene(renderer, &scene);
 

--- a/examples/showfont.c
+++ b/examples/showfont.c
@@ -293,6 +293,10 @@ int main(int argc, char *argv[])
         cleanup(2);
     }
 
+    if (window) {
+        SDL_SetWindowTitle(window, "Show Font");
+    }
+
     /* Show which font file we're looking at */
     SDL_snprintf(string, sizeof(string), "Font file: %s", argv[0]); /* possible overflow */
     switch (rendermethod) {
@@ -427,8 +431,8 @@ int main(int argc, char *argv[])
     done = 0;
     while (!done) {
         if (!SDL_WaitEvent(&event)) {
-            SDL_Log("SDL_PullEvent() error: %s\n", SDL_GetError());
-            done = 1;
+            // SDL_Log("SDL_PullEvent() error: %s\n", SDL_GetError());
+            //  done = 1;
             continue;
         }
         switch (event.type) {
@@ -440,7 +444,7 @@ int main(int argc, char *argv[])
             draw_scene(renderer, &scene);
             break;
 
-        case SDL_EVENT_KEY_DOWN:
+        // case SDL_EVENT_KEY_DOWN:
         case SDL_EVENT_QUIT:
             done = 1;
             break;

--- a/examples/showfont.c
+++ b/examples/showfont.c
@@ -31,18 +31,16 @@
 #include <string.h>
 
 #define DEFAULT_PTSIZE 18
-#define DEFAULT_TEXT   "The quick brown fox jumped over the lazy dog"
+#define DEFAULT_TEXT   "The quick brown fox jumped over the lazy dog."
 #define WIDTH          1280
 #define HEIGHT         800
 
-#define TTF_SHOWFONT_USAGE \
-    "Usage:\n"             \
-    "    %s [-windowsize w,h] [-solid] [-shaded] [-blended] [-wrapped] [-b] [-i] [-u] [-s] [-outline size] [-hintlight | -hintmono | -hintnone] [-nokerning] [-wrap] [-fgcol r,g,b,a] [-bgcol r,g,b,a] [-utf8txtfile pathName] <font>.ttf [ptsize] [text] \n"
-
-#define TTF_SHOWFONT_USAGE_WITH_EXAMPLE                                                                                    \
-    TTF_SHOWFONT_USAGE##"Example:\n"                                                                                       \
-                        "    %s -b -wrap -fgcol 255,0,255,255 -bgcol 64,64,64,255 NotoSansSC.ttf 32 \"This is a test.\"\n" \
-                        "    %s -windowsize 1920,1200 -utf8txtfile content.txt NotoSansSC.ttf"
+#define TTF_SHOWFONT_USAGE                                                                                                                                                                                                                                    \
+    "Usage:\n"                                                                                                                                                                                                                                                \
+    "    %s [-windowsize w,h] [-solid] [-shaded] [-blended] [-wrapped] [-b] [-i] [-u] [-s] [-outline size] [-hintlight | -hintmono | -hintnone] [-nokerning] [-wrap] [-fgcol r,g,b,a] [-bgcol r,g,b,a] [-utf8txtfile pathName] <font>.ttf [ptsize] [text] \n" \
+    "Example:\n"                                                                                                                                                                                                                                              \
+    "    %s -b -wrap -fgcol 255,0,255,255 -bgcol 64,64,64,255 NotoSansSC.ttf 32 \"This is a test.\"\n"                                                                                                                                                        \
+    "    %s -windowsize 1920,1200 -utf8txtfile content.txt NotoSansSC.ttf"
 
 typedef enum
 {
@@ -77,11 +75,15 @@ static void cleanup(int exitcode)
     exit(exitcode);
 }
 
+void show_usage(const char *appName)
+{
+    SDL_Log(TTF_SHOWFONT_USAGE, appName, appName, appName);
+}
+
 int load_file(char **bufferAddr, const char *pathName)
 {
     FILE *file = fopen(pathName, "rb");
-    if (file == NULL)
-    {
+    if (file == NULL) {
         perror("Error opening file");
         return 1;
     }
@@ -89,8 +91,7 @@ int load_file(char **bufferAddr, const char *pathName)
     fseek(file, 0, SEEK_END);
     long file_size = ftell(file);
 
-    if (file_size == 0)
-    {
+    if (file_size == 0) {
         fclose(file);
         return 0;
     }
@@ -102,22 +103,18 @@ int load_file(char **bufferAddr, const char *pathName)
     memset(buffer, 0, file_size + 1);
 
     size_t bytesRead = fread(buffer, 1, file_size, file);
-    if (bytesRead == 0)
-    {
+    if (bytesRead == 0) {
         perror("Error reading file");
         fclose(file);
         return 1;
     }
 
-    if (fread(buffer, file_size, 1, file) != 0)
-    {
+    if (fread(buffer, file_size, 1, file) != 0) {
         return 1;
     }
 
-    for (int i = 0; i < file_size; ++i)
-    {
-        if (iscntrl(buffer[i]))
-        {
+    for (int i = 0; i < file_size; ++i) {
+        if (iscntrl(buffer[i])) {
             buffer[i] = 32;
         }
     }
@@ -174,100 +171,75 @@ int main(int argc, char *argv[])
     forecol = &black;
     backcol = &white;
 
-    if (argc == 1)
-    {
-        printf(TTF_SHOWFONT_USAGE_WITH_EXAMPLE, argv0, argv0, argv0);
+    if (argc == 1) {
+        show_usage(argv0);
         return (1);
     }
 
-    for (i = 1; argv[i] && argv[i][0] == '-'; ++i)
-    {
-        if (SDL_strcmp(argv[i], "-solid") == 0)
-        {
+    for (i = 1; argv[i] && argv[i][0] == '-'; ++i) {
+        if (SDL_strcmp(argv[i], "-solid") == 0) {
             rendermethod = TextRenderSolid;
-        } else if (SDL_strcmp(argv[i], "-shaded") == 0)
-        {
+        } else if (SDL_strcmp(argv[i], "-shaded") == 0) {
             rendermethod = TextRenderShaded;
-        } else if (SDL_strcmp(argv[i], "-blended") == 0)
-        {
+        } else if (SDL_strcmp(argv[i], "-blended") == 0) {
             rendermethod = TextRenderBlended;
-        } else if (SDL_strcmp(argv[i], "-b") == 0)
-        {
+        } else if (SDL_strcmp(argv[i], "-b") == 0) {
             renderstyle |= TTF_STYLE_BOLD;
-        } else if (SDL_strcmp(argv[i], "-i") == 0)
-        {
+        } else if (SDL_strcmp(argv[i], "-i") == 0) {
             renderstyle |= TTF_STYLE_ITALIC;
-        } else if (SDL_strcmp(argv[i], "-u") == 0)
-        {
+        } else if (SDL_strcmp(argv[i], "-u") == 0) {
             renderstyle |= TTF_STYLE_UNDERLINE;
-        } else if (SDL_strcmp(argv[i], "-s") == 0)
-        {
+        } else if (SDL_strcmp(argv[i], "-s") == 0) {
             renderstyle |= TTF_STYLE_STRIKETHROUGH;
-        } else if (SDL_strcmp(argv[i], "-outline") == 0)
-        {
-            if (SDL_sscanf(argv[++i], "%d", &outline) != 1)
-            {
-                SDL_Log(TTF_SHOWFONT_USAGE, argv0);
+        } else if (SDL_strcmp(argv[i], "-outline") == 0) {
+            if (SDL_sscanf(argv[++i], "%d", &outline) != 1) {
+                show_usage(argv0);
                 return (1);
             }
-        } else if (SDL_strcmp(argv[i], "-hintlight") == 0)
-        {
+        } else if (SDL_strcmp(argv[i], "-hintlight") == 0) {
             hinting = TTF_HINTING_LIGHT;
-        } else if (SDL_strcmp(argv[i], "-hintmono") == 0)
-        {
+        } else if (SDL_strcmp(argv[i], "-hintmono") == 0) {
             hinting = TTF_HINTING_MONO;
-        } else if (SDL_strcmp(argv[i], "-hintnone") == 0)
-        {
+        } else if (SDL_strcmp(argv[i], "-hintnone") == 0) {
             hinting = TTF_HINTING_NONE;
-        } else if (SDL_strcmp(argv[i], "-nokerning") == 0)
-        {
+        } else if (SDL_strcmp(argv[i], "-nokerning") == 0) {
             kerning = 0;
-        } else if (SDL_strcmp(argv[i], "-wrap") == 0)
-        {
+        } else if (SDL_strcmp(argv[i], "-wrap") == 0) {
             wrap = 1;
-        } else if (SDL_strcmp(argv[i], "-dump") == 0)
-        {
+        } else if (SDL_strcmp(argv[i], "-dump") == 0) {
             dump = 1;
-        } else if (SDL_strcmp(argv[i], "-fgcol") == 0)
-        {
+        } else if (SDL_strcmp(argv[i], "-fgcol") == 0) {
             int r, g, b, a = 0xFF;
-            if (SDL_sscanf(argv[++i], "%d,%d,%d,%d", &r, &g, &b, &a) < 3)
-            {
-                SDL_Log(TTF_SHOWFONT_USAGE, argv0);
+            if (SDL_sscanf(argv[++i], "%d,%d,%d,%d", &r, &g, &b, &a) < 3) {
+                show_usage(argv0);
                 return (1);
             }
             forecol->r = (Uint8)r;
             forecol->g = (Uint8)g;
             forecol->b = (Uint8)b;
             forecol->a = (Uint8)a;
-        } else if (SDL_strcmp(argv[i], "-bgcol") == 0)
-        {
+        } else if (SDL_strcmp(argv[i], "-bgcol") == 0) {
             int r, g, b, a = 0xFF;
-            if (SDL_sscanf(argv[++i], "%d,%d,%d,%d", &r, &g, &b, &a) < 3)
-            {
-                SDL_Log(TTF_SHOWFONT_USAGE, argv0);
+            if (SDL_sscanf(argv[++i], "%d,%d,%d,%d", &r, &g, &b, &a) < 3) {
+                show_usage(argv0);
                 return (1);
             }
             backcol->r = (Uint8)r;
             backcol->g = (Uint8)g;
             backcol->b = (Uint8)b;
             backcol->a = (Uint8)a;
-        } else if (SDL_strcmp(argv[i], "-utf8txtfile") == 0)
-        {
+        } else if (SDL_strcmp(argv[i], "-utf8txtfile") == 0) {
             load_file(&fileMessage, argv[++i]);
             rendertype = RENDER_UTF8;
             wrap = 1;
-        } else if (SDL_strcmp(argv[i], "-windowsize") == 0)
-        {
-            if (SDL_sscanf(argv[++i], "%d,%d", &winWidth, &winHeight) < 2)
-            {
-                SDL_Log(TTF_SHOWFONT_USAGE, argv0);
+        } else if (SDL_strcmp(argv[i], "-windowsize") == 0) {
+            if (SDL_sscanf(argv[++i], "%d,%d", &winWidth, &winHeight) < 2) {
+                show_usage(argv0);
                 return (1);
             }
-            wrapWidth = winWidth - 10;
-        } else
-        {
-            SDL_Log(TTF_SHOWFONT_USAGE, argv0);
+            wrapWidth = winWidth;
+        } else {
+            show_usage(argv0);
             return (1);
         }
     }
@@ -275,15 +247,13 @@ int main(int argc, char *argv[])
     argc -= i;
 
     /* Check usage */
-    if (!argv[0])
-    {
+    if (!argv[0]) {
         SDL_Log(TTF_SHOWFONT_USAGE, argv0);
         return (1);
     }
 
     /* Initialize the TTF library */
-    if (TTF_Init() < 0)
-    {
+    if (TTF_Init() < 0) {
         SDL_Log("Couldn't initialize TTF: %s\n", SDL_GetError());
         SDL_Quit();
         return (2);
@@ -291,21 +261,17 @@ int main(int argc, char *argv[])
 
     /* Open the font file with the requested point size */
     ptsize = 0;
-    if (argc > 1)
-    {
+    if (argc > 1) {
         ptsize = SDL_atoi(argv[1]);
     }
-    if (ptsize == 0)
-    {
+    if (ptsize == 0) {
         i = 2;
         ptsize = DEFAULT_PTSIZE;
-    } else
-    {
+    } else {
         i = 3;
     }
     font = TTF_OpenFont(argv[0], ptsize);
-    if (font == NULL)
-    {
+    if (font == NULL) {
         SDL_Log("Couldn't load %d pt font from %s: %s\n",
                 ptsize, argv[0], SDL_GetError());
         cleanup(2);
@@ -315,16 +281,13 @@ int main(int argc, char *argv[])
     TTF_SetFontKerning(font, kerning);
     TTF_SetFontHinting(font, hinting);
 
-    if (dump)
-    {
-        for (i = 48; i < 123; i++)
-        {
+    if (dump) {
+        for (i = 48; i < 123; i++) {
             SDL_Surface *glyph = NULL;
 
             glyph = TTF_RenderGlyph_Shaded(font, i, *forecol, *backcol);
 
-            if (glyph)
-            {
+            if (glyph) {
                 char outname[64];
                 SDL_snprintf(outname, sizeof(outname), "glyph-%d.bmp", i);
                 SDL_SaveBMP(glyph, outname);
@@ -334,21 +297,18 @@ int main(int argc, char *argv[])
     }
 
     /* Create a window */
-    if (SDL_CreateWindowAndRenderer(winWidth, winHeight, 0, &window, &renderer) < 0)
-    {
+    if (SDL_CreateWindowAndRenderer(winWidth, winHeight, 0, &window, &renderer) < 0) {
         SDL_Log("SDL_CreateWindowAndRenderer() failed: %s\n", SDL_GetError());
         cleanup(2);
     }
 
-    if (window)
-    {
+    if (window) {
         SDL_SetWindowTitle(window, argv0);
     }
 
     /* Show which font file we're looking at */
     SDL_snprintf(string, sizeof(string), "Font file: %s", argv[0]); /* possible overflow */
-    switch (rendermethod)
-    {
+    switch (rendermethod) {
     case TextRenderSolid:
         text = TTF_RenderText_Solid(font, string, *forecol);
         break;
@@ -359,8 +319,7 @@ int main(int argc, char *argv[])
         text = TTF_RenderText_Blended(font, string, *forecol);
         break;
     }
-    if (text != NULL)
-    {
+    if (text != NULL) {
         scene.captionRect.x = 4.0f;
         scene.captionRect.y = 4.0f;
         scene.captionRect.w = (float)text->w;
@@ -370,49 +329,37 @@ int main(int argc, char *argv[])
     }
 
     /* Render and center the message */
-    if (fileMessage != NULL)
-    {
+    if (fileMessage != NULL) {
         message = fileMessage;
-    } else
-    {
-        if (argc > 2)
-        {
+    } else {
+        if (argc > 2) {
             message = argv[2];
-        } else
-        {
+        } else {
             message = DEFAULT_TEXT;
         }
     }
 
-    switch (rendertype)
-    {
+    switch (rendertype) {
     case RENDER_LATIN1:
-        switch (rendermethod)
-        {
+        switch (rendermethod) {
         case TextRenderSolid:
-            if (wrap)
-            {
+            if (wrap) {
                 text = TTF_RenderText_Solid_Wrapped(font, message, *forecol, wrapWidth);
-            } else
-            {
+            } else {
                 text = TTF_RenderText_Solid(font, message, *forecol);
             }
             break;
         case TextRenderShaded:
-            if (wrap)
-            {
+            if (wrap) {
                 text = TTF_RenderText_Shaded_Wrapped(font, message, *forecol, *backcol, wrapWidth);
-            } else
-            {
+            } else {
                 text = TTF_RenderText_Shaded(font, message, *forecol, *backcol);
             }
             break;
         case TextRenderBlended:
-            if (wrap)
-            {
+            if (wrap) {
                 text = TTF_RenderText_Blended_Wrapped(font, message, *forecol, wrapWidth);
-            } else
-            {
+            } else {
                 text = TTF_RenderText_Blended(font, message, *forecol);
             }
             break;
@@ -420,32 +367,25 @@ int main(int argc, char *argv[])
         break;
 
     case RENDER_UTF8:
-        switch (rendermethod)
-        {
+        switch (rendermethod) {
         case TextRenderSolid:
-            if (wrap)
-            {
+            if (wrap) {
                 text = TTF_RenderUTF8_Solid_Wrapped(font, message, *forecol, wrapWidth);
-            } else
-            {
+            } else {
                 text = TTF_RenderUTF8_Solid(font, message, *forecol);
             }
             break;
         case TextRenderShaded:
-            if (wrap)
-            {
+            if (wrap) {
                 text = TTF_RenderUTF8_Shaded_Wrapped(font, message, *forecol, *backcol, wrapWidth);
-            } else
-            {
+            } else {
                 text = TTF_RenderUTF8_Shaded(font, message, *forecol, *backcol);
             }
             break;
         case TextRenderBlended:
-            if (wrap)
-            {
+            if (wrap) {
                 text = TTF_RenderUTF8_Blended_Wrapped(font, message, *forecol, wrapWidth);
-            } else
-            {
+            } else {
                 text = TTF_RenderUTF8_Blended(font, message, *forecol);
             }
             break;
@@ -455,42 +395,33 @@ int main(int argc, char *argv[])
     case RENDER_UNICODE:
     {
         Uint16 *unicode_text = SDL_iconv_utf8_ucs2(message);
-        switch (rendermethod)
-        {
+        switch (rendermethod) {
         case TextRenderSolid:
-            if (wrap)
-            {
+            if (wrap) {
                 text = TTF_RenderUNICODE_Solid_Wrapped(font, unicode_text, *forecol, wrapWidth);
-            } else
-            {
+            } else {
                 text = TTF_RenderUNICODE_Solid(font, unicode_text, *forecol);
             }
             break;
         case TextRenderShaded:
-            if (wrap)
-            {
+            if (wrap) {
                 text = TTF_RenderUNICODE_Shaded_Wrapped(font, unicode_text, *forecol, *backcol, wrapWidth);
-            } else
-            {
+            } else {
                 text = TTF_RenderUNICODE_Shaded(font, unicode_text, *forecol, *backcol);
             }
             break;
         case TextRenderBlended:
-            if (wrap)
-            {
+            if (wrap) {
                 text = TTF_RenderUNICODE_Blended_Wrapped(font, unicode_text, *forecol, wrapWidth);
-            } else
-            {
+            } else {
                 text = TTF_RenderUNICODE_Blended(font, unicode_text, *forecol);
             }
             break;
         }
         SDL_free(unicode_text);
+    } break;
     }
-    break;
-    }
-    if (text == NULL)
-    {
+    if (text == NULL) {
         SDL_Log("Couldn't render text: %s\n", SDL_GetError());
         TTF_CloseFont(font);
         cleanup(2);
@@ -507,16 +438,13 @@ int main(int argc, char *argv[])
 
     /* Wait for a keystroke, and blit text on mouse press */
     done = 0;
-    while (!done)
-    {
-        if (!SDL_WaitEvent(&event))
-        {
-            // SDL_Log("SDL_PullEvent() error: %s\n", SDL_GetError());
-            //  done = 1;
+    while (!done) {
+        if (!SDL_WaitEvent(&event)) {
+            SDL_Log("SDL_PullEvent() error: %s\n", SDL_GetError());
+            done = 1;
             continue;
         }
-        switch (event.type)
-        {
+        switch (event.type) {
         case SDL_EVENT_MOUSE_BUTTON_DOWN:
             scene.messageRect.x = (float)(event.button.x - text->w / 2);
             scene.messageRect.y = (float)(event.button.y - text->h / 2);
@@ -539,8 +467,7 @@ int main(int argc, char *argv[])
     SDL_DestroyTexture(scene.message);
     cleanup(0);
 
-    if (fileMessage != NULL)
-    {
+    if (fileMessage != NULL) {
         free(fileMessage);
     }
 


### PR DESCRIPTION
Changes for showfont:
- Added argument [-windowsize w,h] to specify the windows size.
- added argument [-utf8txtfile pathName] to support message from utf8 file.
- removed [-utf8|-unicode], since the utf8 or unicode text cannot be input from console.
- fixed [-wrapped] display.
- Set window title.

Other changes:
- Added relative paths(include and link) for VisualC projects.
- Set SubSystem:Console for glfont and showfont.
