### PR TITLE
Pass kerning setting through into harfbuzz shaping (SDL3)

### DIFF
--- a/src/SDL_ttf.c
+++ b/src/SDL_ttf.c
@@ -3226,7 +3226,14 @@ static int TTF_Size_Internal(TTF_Font *font,
 
     /* Layout the text */
     hb_buffer_add_utf8(hb_buffer, text, -1, 0, -1);
-    hb_shape(font->hb_font, hb_buffer, NULL, 0);
+    
+    hb_feature_t userfeatures[1];
+    userfeatures[0].tag = HB_TAG('k','e','r','n');
+    userfeatures[0].value = font->use_kerning;
+    userfeatures[0].start = HB_FEATURE_GLOBAL_START;
+    userfeatures[0].end = HB_FEATURE_GLOBAL_END;
+
+    hb_shape(font->hb_font, hb_buffer, userfeatures, 1);
 
     /* Get the result */
     hb_glyph_info = hb_buffer_get_glyph_infos(hb_buffer, &glyph_count);


### PR DESCRIPTION
Fixes #339 

Version of my patch in #340, but against main instead of SDL2. I tested the SDL2 version, I have not tested this version because I don't have working SDL3 environment the way I do with SDL2. But this area of the code doesn't look like it has changed at all between branches.