### PR TITLE
cmake: use MACHO* properties to set macho version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -263,23 +263,6 @@ elseif (UNIX AND NOT APPLE AND NOT ANDROID)
         VERSION "${LT_VERSION}"
     )
 endif()
-if (BUILD_SHARED_LIBS)
-    if (WIN32 OR OS2)
-        set_target_properties(SDL2_ttf PROPERTIES
-            PREFIX ""
-        )
-    endif()
-    if (OS2)
-        # OS/2 doesn't support a DLL name longer than 8 characters.
-        set_target_properties(SDL2_ttf PROPERTIES
-           OUTPUT_NAME "SDL2ttf"
-        )
-    elseif (UNIX AND NOT APPLE AND NOT ANDROID)
-        set_target_properties(SDL2_ttf PROPERTIES
-            OUTPUT_NAME "SDL2_ttf-${LT_RELEASE}"
-        )
-    endif()
-endif()
 
 # Restore BUILD_SHARED_LIBS variable
 set(BUILD_SHARED_LIBS "${SDL2TTF_BUILD_SHARED_LIBS}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -120,11 +120,11 @@ if(NOT ANDROID)
         DEBUG_POSTFIX "${SDL2TTF_DEBUG_POSTFIX}"
     )
     if(APPLE)
-        # the SOVERSION property corresponds to the compatibility version and VERSION corresponds to the current version
-        # https://cmake.org/cmake/help/latest/prop_tgt/SOVERSION.html#mach-o-versions
+        cmake_minimum_required(VERSION 3.17)
         set_target_properties(SDL2_ttf PROPERTIES
-            SOVERSION "${DYLIB_COMPATIBILITY_VERSION}"
-            VERSION "${DYLIB_CURRENT_VERSION}"
+            SOVERSION "${LT_MAJOR}"
+            MACHO_COMPATIBILITY_VERSION "${DYLIB_COMPATIBILITY_VERSION}"
+            MACHO_CURRENT_VERSION "${MACHO_CURRENT_VERSION}"
         )
     else()
         set_target_properties(SDL2_ttf PROPERTIES


### PR DESCRIPTION
Currently, [`VERSION`](https://cmake.org/cmake/help/latest/prop_tgt/VERSION.html) and [`SOVERSION`](https://cmake.org/cmake/help/latest/prop_tgt/SOVERSION.html] determine the file name and the macho compatibility and current version.

With this changes, `VERSION` and `SOVERSION` only determine the filename.
[`MACHO_COMPATIBILITY_VERSION`](https://cmake.org/cmake/help/latest/prop_tgt/MACHO_COMPATIBILITY_VERSION.html) and [`MACHO_CURRENT_VERSION`](https://cmake.org/cmake/help/latest/prop_tgt/MACHO_CURRENT_VERSION.html) set the internal macho properties.

This also bumps the minimum required version on macos to 3.17,

Should fix https://github.com/libsdl-org/SDL_ttf/issues/347