### PR TITLE
Let HarfBuzz decide which script, direction and language to use in case not set

### DIFF
--- a/src/SDL_ttf.c
+++ b/src/SDL_ttf.c
@@ -3221,6 +3221,7 @@ static int TTF_Size_Internal(TTF_Font *font,
     hb_buffer_set_language(hb_buffer, font->hb_language);
     hb_buffer_set_direction(hb_buffer, hb_direction);
     hb_buffer_set_script(hb_buffer, hb_script);
+    hb_buffer_guess_segment_properties(hb_buffer);
 
     /* Layout the text */
     hb_buffer_add_utf8(hb_buffer, text, -1, 0, -1);


### PR DESCRIPTION
Text has rules and settings needed for its rendering depending on its characters. Scripts, text direction and language are settings that should be changed depending on the characters and their context. These change the visual effect on the rendered text.

At the moment SDL_TTF provides us the possibility to set any of these three settings but always defaults to an invalid setting on each. With `hb_buffer_guess_segment_properties()` these could be deducted if not set and it should be the default for rendering text correctly.

See https://github.com/libsdl-org/SDL_ttf/issues/365