### PR TITLE
Fix SDL_memcmp argument mismatch in SDL_ttf.c

### DIFF
--- a/src/SDL_ttf.c
+++ b/src/SDL_ttf.c
@@ -4314,7 +4314,7 @@ bool TTF_SetTextString(TTF_Text *text, const char *string, size_t length)
             length = SDL_strlen(string);
         }
 
-        if (text->text && length == SDL_strlen(text->text) && SDL_memcmp(text, text->text, length) == 0) {
+        if (text->text && length == SDL_strlen(text->text) && SDL_memcmp(string, text->text, length) == 0) {
             return true;
         }
 


### PR DESCRIPTION
Corrected the SDL_memcmp function to compare the 'string' argument instead of 'text', ensuring proper string comparison logic. This resolves potential functional issues caused by the incorrect argument usage.

Before the fix:
```
// init code
TTF_Text* Txt = TTF_CreateText(SomeTextEngine, SomeFont, "0", 1);
// ... change the text
TTF_SetTextString(Txt, "1", 1)
Assert( StrCmp(Txt->text, "1") == 0 ) // <-- this fails, Txt->text remains "0" 
```

After the fix:
```
// init code
TTF_Text* Txt = TTF_CreateText(SomeTextEngine, SomeFont, "0", 1);
// ... change the text
TTF_SetTextString(Txt, "1", 1)
Assert( StrCmp(Txt->text, "1") == 0 ) // <-- OK, Txt->text is "1"
```