### PR TITLE
Fixed a typo in the documentation for TTF_OpenFontWithProperties and added TTF_FontStyleFlags

### DIFF
--- a/include/SDL3_ttf/SDL_ttf.h
+++ b/include/SDL3_ttf/SDL_ttf.h
@@ -354,6 +354,9 @@ extern SDL_DECLSPEC bool SDLCALL TTF_GetFontDPI(TTF_Font *font, int *hdpi, int *
 /**
  * Font style flags
  */
+
+typedef Sint32 TTF_FontStyleFlags;
+
 #define TTF_STYLE_NORMAL        0x00
 #define TTF_STYLE_BOLD          0x01
 #define TTF_STYLE_ITALIC        0x02
@@ -384,7 +387,7 @@ extern SDL_DECLSPEC bool SDLCALL TTF_GetFontDPI(TTF_Font *font, int *hdpi, int *
  *
  * \sa TTF_GetFontStyle
  */
-extern SDL_DECLSPEC void SDLCALL TTF_SetFontStyle(TTF_Font *font, int style);
+extern SDL_DECLSPEC void SDLCALL TTF_SetFontStyle(TTF_Font *font, TTF_FontStyleFlags style);
 
 /**
  * Query a font's current style.
@@ -406,7 +409,7 @@ extern SDL_DECLSPEC void SDLCALL TTF_SetFontStyle(TTF_Font *font, int style);
  *
  * \sa TTF_SetFontStyle
  */
-extern SDL_DECLSPEC int SDLCALL TTF_GetFontStyle(const TTF_Font *font);
+extern SDL_DECLSPEC TTF_FontStyleFlags SDLCALL TTF_GetFontStyle(const TTF_Font *font);
 
 /**
  * Set a font's current outline.

--- a/include/SDL3_ttf/SDL_ttf.h
+++ b/include/SDL3_ttf/SDL_ttf.h
@@ -194,7 +194,7 @@ extern SDL_DECLSPEC TTF_Font * SDLCALL TTF_OpenFontIO(SDL_IOStream *src, bool cl
  *   for the beginning of the font, defaults to 0.
  * - `TTF_PROP_FONT_CREATE_IOSTREAM_AUTOCLOSE_BOOLEAN`: true if closing the
  *   font should also close the associated SDL_IOStream.
- * - `TTF_PROP_FONT_CREATE_SIZE_NUMBER`: the point size of the font. Some .fon
+ * - `TTF_PROP_FONT_CREATE_SIZE_FLOAT`: the point size of the font. Some .fon
  *   fonts will have several sizes embedded in the file, so the point size
  *   becomes the index of choosing which size. If the value is too high, the
  *   last indexed size will be the default.

--- a/src/SDL_ttf.c
+++ b/src/SDL_ttf.c
@@ -4986,7 +4986,7 @@ bool TTF_GetFontDPI(TTF_Font *font, int *hdpi, int *vdpi)
     return true;
 }
 
-void TTF_SetFontStyle(TTF_Font *font, int style)
+void TTF_SetFontStyle(TTF_Font *font, TTF_FontStyleFlags style)
 {
     int prev_style;
     long face_style;
@@ -5019,7 +5019,7 @@ void TTF_SetFontStyle(TTF_Font *font, int style)
     UpdateFontText(font);
 }
 
-int TTF_GetFontStyle(const TTF_Font *font)
+TTF_FontStyleFlags TTF_GetFontStyle(const TTF_Font *font)
 {
     int style;
     long face_style;


### PR DESCRIPTION
The TTF_SetFontStyle method does not accept any value other than TTF_STYLE_NORMAL, TTF_STYLE_BOLD, TTF_STYLE_ITALIC, TTF_STYLE_UNDERLINE, TTF_STYLE_STRIKETHROUGH and never will in the future.

The TTF_GetFontStyle method will never return a value other than these either.

That's why, I think, it will be more convenient and intuitive to operate with a flag and will help to avoid errors when a value that does not correspond to the value of constants is passed to the method.