### PR TITLE
GPU Metal fixes

### DIFF
--- a/examples/testgputext.c
+++ b/examples/testgputext.c
@@ -11,7 +11,7 @@
 
 #define MAX_VERTEX_COUNT 4000
 #define MAX_INDEX_COUNT  6000
-#define SUPPORTED_SHADER_FORMATS (SDL_GPU_SHADERFORMAT_SPIRV | SDL_GPU_SHADERFORMAT_DXBC | SDL_GPU_SHADERFORMAT_DXIL | SDL_GPU_SHADERFORMAT_METALLIB)
+#define SUPPORTED_SHADER_FORMATS (SDL_GPU_SHADERFORMAT_SPIRV | SDL_GPU_SHADERFORMAT_DXBC | SDL_GPU_SHADERFORMAT_DXIL | SDL_GPU_SHADERFORMAT_MSL)
 
 typedef SDL_FPoint Vec2;
 
@@ -89,11 +89,11 @@ SDL_GPUShader *load_shader(
         createinfo.code = is_vertex ? shader_vert_sm60_dxil : shader_frag_sm60_dxil;
         createinfo.code_size = is_vertex ? SDL_arraysize(shader_vert_sm60_dxil) : SDL_arraysize(shader_frag_sm60_dxil);
         createinfo.entrypoint = is_vertex ? "VSMain" : "PSMain";
-    } else if (format & SDL_GPU_SHADERFORMAT_METALLIB) {
-        createinfo.format = SDL_GPU_SHADERFORMAT_METALLIB;
+    } else if (format & SDL_GPU_SHADERFORMAT_MSL) {
+        createinfo.format = SDL_GPU_SHADERFORMAT_MSL;
         createinfo.code = is_vertex ? shader_vert_metal : shader_frag_metal;
         createinfo.code_size = is_vertex ? shader_vert_metal_len : shader_frag_metal_len;
-        createinfo.entrypoint = is_vertex ? "vs_main" : "fs_main";
+        createinfo.entrypoint = "main0";
     } else {
         createinfo.format = SDL_GPU_SHADERFORMAT_SPIRV;
         createinfo.code = is_vertex ? shader_vert_spv : shader_frag_spv;

--- a/src/SDL_gpu_textengine.c
+++ b/src/SDL_gpu_textengine.c
@@ -182,7 +182,7 @@ static AtlasTexture *CreateAtlas(SDL_GPUDevice *device)
     SDL_GPUTextureCreateInfo info = { 0 };
     info.type = SDL_GPU_TEXTURETYPE_2D;
     info.format = SDL_GPU_TEXTUREFORMAT_R8G8B8A8_UNORM;
-    info.usage = SDL_GPU_TEXTUREUSAGE_SAMPLER;
+    info.usage = SDL_GPU_TEXTUREUSAGE_SAMPLER | SDL_GPU_TEXTUREUSAGE_COLOR_TARGET;
     info.width = ATLAS_TEXTURE_SIZE;
     info.height = ATLAS_TEXTURE_SIZE;
     info.layer_count_or_depth = 1;
@@ -194,6 +194,17 @@ static AtlasTexture *CreateAtlas(SDL_GPUDevice *device)
         DestroyAtlas(device, atlas);
         return NULL;
     }
+
+    SDL_GPUColorTargetInfo target_info;
+    SDL_zero(target_info);
+    target_info.texture = atlas->texture;
+    target_info.clear_color = (SDL_FColor) { 0, 0, 0, 0 };
+    target_info.load_op = SDL_GPU_LOADOP_CLEAR;
+
+    SDL_GPUCommandBuffer *cbuf = SDL_AcquireGPUCommandBuffer(device);
+    SDL_GPURenderPass *rpass = SDL_BeginGPURenderPass(cbuf, &target_info, 1, NULL);
+    SDL_EndGPURenderPass(rpass);
+    SDL_SubmitGPUCommandBuffer(cbuf);
 
     int num_nodes = ATLAS_TEXTURE_SIZE / 4;
     atlas->packing_nodes = (stbrp_node *)SDL_calloc(num_nodes, sizeof(*atlas->packing_nodes));


### PR DESCRIPTION
The Metal shaders provided are actually MSL, just in a byte array format, so I made some fixes to properly load the shaders.

Additionally, the atlas's texture contents are undefined outside of the regions that have been explicitly uploaded, so we should explicitly clear the atlas texture upfront. This fixes the pink line issue mentioned here: https://github.com/libsdl-org/SDL_ttf/issues/452