### PR TITLE
testgputext: Be less dependent on a bundled font

### DIFF
--- a/examples/testgputext.c
+++ b/examples/testgputext.c
@@ -328,6 +328,8 @@ int main(int argc, char *argv[])
 
     check_error_bool(TTF_Init());
     TTF_Font *font = check_error_ptr(TTF_OpenFont("NotoSansMono-Regular.ttf", 50));
+    if (!font)
+        running = false;
     TTF_SetFontWrapAlignment(font, TTF_HORIZONTAL_ALIGN_CENTER);
     TTF_TextEngine *engine = check_error_ptr(TTF_CreateGPUTextEngine(context.device));
 

--- a/examples/testgputext.c
+++ b/examples/testgputext.c
@@ -224,8 +224,10 @@ void free_context(Context *context)
 
 int main(int argc, char *argv[])
 {
-    (void)argc;
-    (void)argv;
+    const char *font_filename = "NotoSansMono-Regular.ttf";
+
+    if (argc > 1)
+        font_filename = argv[1];
 
     check_error_bool(SDL_Init(SDL_INIT_VIDEO | SDL_INIT_EVENTS));
 
@@ -327,7 +329,7 @@ int main(int argc, char *argv[])
     geometry_data.indices = SDL_calloc(MAX_INDEX_COUNT, sizeof(int));
 
     check_error_bool(TTF_Init());
-    TTF_Font *font = check_error_ptr(TTF_OpenFont("NotoSansMono-Regular.ttf", 50));
+    TTF_Font *font = check_error_ptr(TTF_OpenFont(font_filename, 50));
     if (!font)
         running = false;
     TTF_SetFontWrapAlignment(font, TTF_HORIZONTAL_ALIGN_CENTER);


### PR DESCRIPTION
Linux distributions generally don't like convenience copies of "stuff" that conceptually belongs to one package being included in a different package, because they cause duplication between packages, require extra copyright/license bookkeeping, and/or require maintainers to track down corresponding source code in order to meet the distro's self-imposed rules; so I'd prefer not to include a convenience copy of Noto in the Debian-packaged version of SDL_ttf. I can do most of this as Debian-specific changes, but some of them seem like they would equally make sense upstream:

* testgputext: Don't crash if the desired font cannot be found in the cwd

* testgputext: Allow a font filename to be given on the command-line
    
    This allows it to be used as an "as-installed" test, just like
    showfont and glfont, without needing to bundle a specific font file
    or be in a specific directory.