### PR TITLE
Update SDL_gpu_textengine.c

### DIFF
--- a/src/SDL_gpu_textengine.c
+++ b/src/SDL_gpu_textengine.c
@@ -630,7 +630,7 @@ static AtlasDrawSequence *CreateDrawSequence(TTF_DrawOperation *ops, int num_ops
 
         float *uv = (float *)sequence->uv;
         for (int i = 0; i < count; ++i) {
-            AtlasGlyph *glyph = (AtlasGlyph *)ops[i].copy.reserved;
+            glyph = (AtlasGlyph *)ops[i].copy.reserved;
             SDL_memcpy(uv, glyph->texcoords, sizeof(glyph->texcoords));
             uv += SDL_arraysize(glyph->texcoords);
         }


### PR DESCRIPTION
fix: `error: declaration shadows a local variable [-Werror,-Wshadow]`

`AtlasGlyph *glyph;` is declared on line [623](https://github.com/libsdl-org/SDL_ttf/blob/db009130951541b4704c98e3ff4595dbced35dbe/src/SDL_gpu_textengine.c#L623) and then another variable with the same name is declared on line [633](https://github.com/libsdl-org/SDL_ttf/blob/db009130951541b4704c98e3ff4595dbced35dbe/src/SDL_gpu_textengine.c#L633). 

Note: `AtlasGlyph *glyph;` is declared on line [623](https://github.com/libsdl-org/SDL_ttf/blob/db009130951541b4704c98e3ff4595dbced35dbe/src/SDL_gpu_textengine.c#L623) only because line [625](https://github.com/libsdl-org/SDL_ttf/blob/db009130951541b4704c98e3ff4595dbced35dbe/src/SDL_gpu_textengine.c#L625) uses it for sizeof in the malloc call.