### PR TITLE
Update SDL_ttf.c

### DIFF
--- a/src/SDL_ttf.c
+++ b/src/SDL_ttf.c
@@ -5253,13 +5253,6 @@ bool TTF_GetFontKerning(const TTF_Font *font)
     return font->enable_kerning;
 }
 
-int TTF_GetNumFontFaces(const TTF_Font *font)
-{
-    TTF_CHECK_FONT(font, 0);
-
-    return (int)font->face->num_faces;
-}
-
 bool TTF_FontIsFixedWidth(const TTF_Font *font)
 {
     TTF_CHECK_FONT(font, false);


### PR DESCRIPTION
Fix: `error: no previous prototype for function 'TTF_GetNumFontFaces' [-Werror,-Wmissing-prototypes]`

Function TTF_GetNumFontFaces was made obsolete in commit: https://github.com/libsdl-org/SDL_ttf/commit/c4383450236973c878ba84f323cc8c86751b2d36

Unsure if function is being kept around for backwards compatibility or something.