### PR TITLE
Some minor improvements

### DIFF
--- a/examples/testgputext.c
+++ b/examples/testgputext.c
@@ -339,15 +339,16 @@ int main(int argc, char *argv[])
     TTF_SetFontWrapAlignment(font, TTF_HORIZONTAL_ALIGN_CENTER);
     TTF_TextEngine *engine = check_error_ptr(TTF_CreateGPUTextEngine(context.device));
 
+    char str[] = "     \nSDL is cool";
+    TTF_Text *text = check_error_ptr(TTF_CreateText(engine, font, str, 0));
+
     SDL_Mat4X4 *matrices = (SDL_Mat4X4[]){
         SDL_MatrixPerspective(SDL_PI_F / 2.0f, 800.0f / 600.0f, 0.1f, 100.0f),
         SDL_MatrixIdentity()
     };
 
     float rot_angle = 0;
-    char str[] = "     \nSDL is cool";
     SDL_FColor colour = {1.0f, 1.0f, 0.0f, 1.0f};
-    TTF_Text *text = check_error_ptr(TTF_CreateText(engine, font, str, 0));
 
     while (running) {
         SDL_Event event;
@@ -362,10 +363,10 @@ int main(int argc, char *argv[])
         for (int i = 0; i < 5; i++) {
             str[i] = 65 + SDL_rand(26);
         }
+        TTF_SetTextString(text, str, 0);
 
         int tw, th;
         check_error_bool(TTF_GetTextSize(text, &tw, &th));
-        TTF_SetTextString(text, str, 0);
 
         rot_angle = SDL_fmodf(rot_angle + 0.01, 2 * SDL_PI_F);
 

--- a/include/SDL3_ttf/SDL_ttf.h
+++ b/include/SDL3_ttf/SDL_ttf.h
@@ -1810,6 +1810,8 @@ extern SDL_DECLSPEC SDL_PropertiesID SDLCALL TTF_GetTextProperties(TTF_Text *tex
 
 /**
  * Set the text engine used by a text object.
+ * 
+ * This function may cause the internal text representation to be rebuilt.
  *
  * \param text the TTF_Text to modify.
  * \param engine the text engine to use for drawing.
@@ -1847,6 +1849,8 @@ extern SDL_DECLSPEC TTF_TextEngine * SDLCALL TTF_GetTextEngine(TTF_Text *text);
  * When a text object has a font, any changes to the font will automatically
  * regenerate the text. If you set the font to NULL, the text will continue to
  * render but changes to the font will no longer affect the text.
+ * 
+ * This function may cause the internal text representation to be rebuilt.
  *
  * \param text the TTF_Text to modify.
  * \param font the font to use, may be NULL.
@@ -1979,6 +1983,8 @@ extern SDL_DECLSPEC bool SDLCALL TTF_GetTextColorFloat(TTF_Text *text, float *r,
  *
  * This can be used to position multiple text objects within a single wrapping
  * text area.
+ * 
+ * This function may cause the internal text representation to be rebuilt.
  *
  * \param text the TTF_Text to modify.
  * \param x the x offset of the upper left corner of this text in pixels.
@@ -2013,6 +2019,8 @@ extern SDL_DECLSPEC bool SDLCALL TTF_GetTextPosition(TTF_Text *text, int *x, int
 
 /**
  * Set whether wrapping is enabled on a text object.
+ * 
+ * This function may cause the internal text representation to be rebuilt.
  *
  * \param text the TTF_Text to modify.
  * \param wrap_width the maximum width in pixels, 0 to wrap on newline
@@ -2054,6 +2062,8 @@ extern SDL_DECLSPEC bool SDLCALL TTF_GetTextWrapWidth(TTF_Text *text, int *wrap_
  * alignment and wrapping. This is good for editing, but looks better when
  * centered or aligned if whitespace around line wrapping is hidden. This
  * defaults false.
+ * 
+ * This function may cause the internal text representation to be rebuilt.
  *
  * \param text the TTF_Text to modify.
  * \param visible true to show whitespace when wrapping text, false to hide
@@ -2088,6 +2098,8 @@ extern SDL_DECLSPEC bool SDLCALL TTF_TextWrapWhitespaceVisible(TTF_Text *text);
 
 /**
  * Set the UTF-8 text used by a text object.
+ * 
+ * This function may cause the internal text representation to be rebuilt.
  *
  * \param text the TTF_Text to modify.
  * \param string the UTF-8 text to use, may be NULL.
@@ -2109,6 +2121,8 @@ extern SDL_DECLSPEC bool SDLCALL TTF_SetTextString(TTF_Text *text, const char *s
 
 /**
  * Insert UTF-8 text into a text object.
+ * 
+ * This function may cause the internal text representation to be rebuilt.
  *
  * \param text the TTF_Text to modify.
  * \param offset the offset, in bytes, from the beginning of the string if >=
@@ -2134,6 +2148,8 @@ extern SDL_DECLSPEC bool SDLCALL TTF_InsertTextString(TTF_Text *text, int offset
 
 /**
  * Append UTF-8 text to a text object.
+ * 
+ * This function may cause the internal text representation to be rebuilt.
  *
  * \param text the TTF_Text to modify.
  * \param string the UTF-8 text to insert.
@@ -2155,6 +2171,8 @@ extern SDL_DECLSPEC bool SDLCALL TTF_AppendTextString(TTF_Text *text, const char
 
 /**
  * Delete UTF-8 text from a text object.
+ * 
+ * This function may cause the internal text representation to be rebuilt.
  *
  * \param text the TTF_Text to modify.
  * \param offset the offset, in bytes, from the beginning of the string if >=


### PR DESCRIPTION
* Updated the testgputext example to use the latest best practices
* Updated the documentation to mention which TTF_SetText* functions can cause the internal text atlas to update/change.