### PR TITLE
Find in hash table, use correct value size

### DIFF
--- a/src/SDL_ttf.c
+++ b/src/SDL_ttf.c
@@ -2967,9 +2967,12 @@ static bool Find_GlyphByIndex(TTF_Font *font, FT_UInt idx,
 static FT_UInt get_char_index(TTF_Font *font, Uint32 ch)
 {
     FT_UInt idx = 0;
-    if (!SDL_FindInHashTable(font->glyph_indices, (const void *)(uintptr_t)ch, (const void **)&idx)) {
+    const void *value;
+    if (!SDL_FindInHashTable(font->glyph_indices, (const void *)(uintptr_t)ch, &value)) {
         idx = FT_Get_Char_Index(font->face, ch);
         SDL_InsertIntoHashTable(font->glyph_indices, (const void *)(uintptr_t)ch, (const void *)(uintptr_t)idx);
+    } else {
+        idx = (FT_UInt)(uintptr_t)value;
     }
     return idx;
 }


### PR DESCRIPTION
Hey @slouken 
This fix a crash in lastest version.  *** stack smashing detected ***: terminated
because the key have has to be a ptr size.

Besides, I tested with/without a hash-table for glyph_indice, and there is not difference in speed. So probably freetype FT_Get_Char_Index is already optimized and we need no glyph_indice table.

