### PR TITLE
ASAN Issue

### DIFF
--- a/src/SDL_renderer_textengine.c
+++ b/src/SDL_renderer_textengine.c
@@ -367,7 +367,9 @@ static bool ResolveMissingGlyphs(TTF_RendererTextEngineData *enginedata, AtlasTe
             // Remove this from the missing entries
             --num_missing;
             if (i < num_missing) {
-                SDL_memcpy(&missing[i], &missing[i+1], (num_missing - i) * sizeof(missing[i]));
+                for (int j = i; j < num_missing; ++j) {
+                    missing[j] = missing[j + 1];
+                }
             }
         }
         if (num_missing == 0) {

--- a/src/SDL_renderer_textengine.c
+++ b/src/SDL_renderer_textengine.c
@@ -367,9 +367,7 @@ static bool ResolveMissingGlyphs(TTF_RendererTextEngineData *enginedata, AtlasTe
             // Remove this from the missing entries
             --num_missing;
             if (i < num_missing) {
-                for (int j = i; j < num_missing; ++j) {
-                    missing[j] = missing[j + 1];
-                }
+                SDL_memmove(&missing[i], &missing[i + 1], (num_missing - i) * sizeof(missing[i]));
             }
         }
         if (num_missing == 0) {


### PR DESCRIPTION
On MSVC I get a
```
==9952==ERROR: AddressSanitizer: memcpy-param-overlap: memory ranges [0x11e8718f6e00,0x11e8718f6e78) and [0x11e8718f6e18, 0x11e8718f6e90) overlap
```
Since the CRT `memcpy` memory is not allowed to overlap (see: https://learn.microsoft.com/en-us/cpp/sanitizers/error-memcpy-param-overlap?view=msvc-170 ) And `SDL_memcpy` uses `memcpy` by default.

This fix might be sufficient.
Another alternative is to use `memmove` to move overlapping memory.