### PR TITLE
Add font weight functionality

### DIFF
--- a/include/SDL3_ttf/SDL_ttf.h
+++ b/include/SDL3_ttf/SDL_ttf.h
@@ -445,7 +445,7 @@ extern SDL_DECLSPEC bool SDLCALL TTF_GetFontDPI(TTF_Font *font, int *hdpi, int *
  * SDL_ttf. A combination of these flags can be used with functions that set
  * or query font style, such as TTF_SetFontStyle or TTF_GetFontStyle.
  *
- * \since This function is available since SDL_ttf 3.0.0.
+ * \since This datatype is available since SDL_ttf 3.0.0.
  *
  * \sa TTF_SetFontStyle
  * \sa TTF_GetFontStyle
@@ -664,6 +664,30 @@ extern SDL_DECLSPEC bool SDLCALL TTF_SetFontSDF(TTF_Font *font, bool enabled);
  * \sa TTF_SetFontSDF
  */
 extern SDL_DECLSPEC bool SDLCALL TTF_GetFontSDF(const TTF_Font *font);
+
+/**
+ * Query a font's weight, in terms of the lightness/heaviness of the strokes.
+ *
+ * \param font the font to query.
+ * \returns the font's current weight
+ *
+ * \threadsafety This function should be called on the thread that created the
+ *               font.
+ *
+ * \since This function is available since SDL_ttf 3.4.0.
+ */
+extern SDL_DECLSPEC int SDLCALL TTF_GetFontWeight(const TTF_Font *font);
+
+#define TTF_FONT_WEIGHT_THIN        100 /**< Thin (100) named font weight value */
+#define TTF_FONT_WEIGHT_EXTRA_LIGHT 200 /**< ExtraLight (200) named font weight value */
+#define TTF_FONT_WEIGHT_LIGHT       300 /**< Light (300) named font weight value */
+#define TTF_FONT_WEIGHT_NORMAL      400 /**< Normal (400) named font weight value */
+#define TTF_FONT_WEIGHT_MEDIUM      500 /**< Medium (500) named font weight value */
+#define TTF_FONT_WEIGHT_SEMI_BOLD   600 /**< SemiBold (600) named font weight value */
+#define TTF_FONT_WEIGHT_BOLD        700 /**< Bold (700) named font weight value */
+#define TTF_FONT_WEIGHT_EXTRA_BOLD  800 /**< ExtraBold (800) named font weight value */
+#define TTF_FONT_WEIGHT_BLACK       900 /**< Black (900) named font weight value */
+#define TTF_FONT_WEIGHT_EXTRA_BLACK 950 /**< ExtraBlack (950) named font weight value */
 
 /**
  * The horizontal alignment used when rendering wrapped text.

--- a/src/SDL_ttf.sym
+++ b/src/SDL_ttf.sym
@@ -38,6 +38,7 @@ SDL3_ttf_0.0.0 {
     TTF_GetFontSize;
     TTF_GetFontStyle;
     TTF_GetFontStyleName;
+    TTF_GetFontWeight;
     TTF_GetFontWrapAlignment;
     TTF_GetFreeTypeVersion;
     TTF_GetGlyphImage;


### PR DESCRIPTION
Solves #527.

Adds `weight` to `TTF_Font` (which is retrieved from a font's [OS/2 table](https://learn.microsoft.com/en-us/typography/opentype/spec/os2)), as well as `TTF_GetFontWeight`—which is used to retrieve this value.

Also adds a set of `#define`s that correspond to [commonly-used named font weight values](https://developer.mozilla.org/en-US/docs/Web/CSS/font-weight#common_weight_name_mapping). These can be used for ‘categorising’ fonts to certain weight classes, and will also be useful for setting the `wght` value for font variations (#506).

This pull request also fixes a minor documentation comment error.