### PR TITLE
Add TTF_GetFontBBox() which returns font's extremum bounding box

### DIFF
--- a/SDL_ttf.c
+++ b/SDL_ttf.c
@@ -3040,6 +3040,27 @@ void TTF_SetFontKerning(TTF_Font *font, int allowed)
 #endif
 }
 
+void TTF_GetFontBBox(const TTF_Font *font, int *minx, int *maxx, int *miny, int *maxy)
+{
+    if (!font || !font->face) {
+        return;
+    }
+    /* Recalculate FT_Face's bbox from font units to pixels */
+    const FT_Face face = font->face;
+    if (minx) {
+        *minx = FT_MulFix(FT_DivFix(face->bbox.xMin, face->units_per_EM), face->size->metrics.x_ppem);
+    }
+    if (maxx) {
+        *maxx = FT_MulFix(FT_DivFix(face->bbox.xMax, face->units_per_EM), face->size->metrics.x_ppem);
+    }
+    if (miny) {
+        *miny = FT_MulFix(FT_DivFix(face->bbox.yMin, face->units_per_EM), face->size->metrics.y_ppem);
+    }
+    if (maxy) {
+        *maxy = FT_MulFix(FT_DivFix(face->bbox.yMax, face->units_per_EM), face->size->metrics.y_ppem);
+    }
+}
+
 long TTF_FontFaces(const TTF_Font *font)
 {
     return font->face->num_faces;

--- a/SDL_ttf.h
+++ b/SDL_ttf.h
@@ -679,6 +679,22 @@ extern DECLSPEC int SDLCALL TTF_GetFontKerning(const TTF_Font *font);
 extern DECLSPEC void SDLCALL TTF_SetFontKerning(TTF_Font *font, int allowed);
 
 /**
+ * Query the font bounding box.
+ * 
+ * The bounding box defines bounds large enough to contain any glyph from
+ * the font. It is expressed in pixel offsets from glyph's origin (0,0),
+ * with Y axis pointing upwards. Thus ymax offset may be seen as the
+ * "maximum ascender" and ymin offset - as the "minimum descender".
+ *
+ * \param font the font to query.
+ *
+ * \since This function is available since SDL_ttf 2.26.0.
+ */
+extern DECLSPEC void SDLCALL TTF_GetFontBBox(const TTF_Font *font,
+                        int *minx, int *maxx,
+                        int *miny, int *maxy);
+
+/**
  * Query the number of faces of a font.
  *
  * \param font the font to query.


### PR DESCRIPTION
Resolve #536

This adds a new function called TTF_GetFontBBox:
```
extern DECLSPEC void SDLCALL TTF_GetFontBBox(const TTF_Font *font, TTF_BBox *bbox);
```
and a struct TTF_BBox (simply a pair of xmin/max and ymin/max offsets).

This function may be used to query font's bbox, which is a bounding box enough to suit any glyph from this font.
Function description is based on FreeType comments to FT_Face's bbox field.

I was not certain which version to mention in comments, so put 2.26.0, as that seems to be the next release number, theoretically?