### PR TITLE
Fixed bug #537 - prevent incrementing a null pointer 'image->buffer',

### DIFF
--- a/src/SDL_ttf.c
+++ b/src/SDL_ttf.c
@@ -1188,10 +1188,15 @@ static bool Render_Line_##NAME(TTF_Font *font, SDL_Surface *textbuf, int xstart,
             int remainder;                                                                                              \
             Uint8 *saved_buffer = image->buffer;                                                                        \
             int saved_width = image->width;                                                                             \
-            image->buffer += alignment;                                                                                 \
+                                                                                                                        \
             /* Position updated after glyph rendering */                                                                \
             x = xstart + FT_FLOOR(x) + image->left;                                                                     \
             y = ystart + FT_FLOOR(y) - image->top;                                                                      \
+                                                                                                                        \
+            if (image->buffer == NULL) {                                                                                \
+                continue;                                                                                               \
+            }                                                                                                           \
+            image->buffer += alignment;                                                                                 \
                                                                                                                         \
             /* Make sure glyph is inside textbuf */                                                                     \
             above_w = x + image->width - textbuf->w;                                                                    \


### PR DESCRIPTION
      which would be detected by UBsan sanitizer.