### PR TITLE
Remove a misaligned pointer cast in BG_Blended_LCD

### DIFF
--- a/src/SDL_ttf.c
+++ b/src/SDL_ttf.c
@@ -456,7 +456,7 @@ static bool Find_GlyphByIndex(TTF_Font *font, FT_UInt idx, int want_bitmap, int 
 // Blend colored glyphs
 static void BG_Blended_Color(const TTF_Image *image, Uint32 *destination, Sint32 srcskip, Uint32 dstskip, Uint8 fg_alpha)
 {
-    const Uint32 *src   = (Uint32 *)image->buffer;
+    const Uint8  *src   = image->buffer;
     Uint32      *dst    = destination;
     Uint32       width  = image->width;
     Uint32       height = image->rows;
@@ -465,10 +465,12 @@ static void BG_Blended_Color(const TTF_Image *image, Uint32 *destination, Sint32
         while (height--) {
             /* *INDENT-OFF* */
             DUFFS_LOOP4(
-                *dst++ = *src++;
+                SDL_memcpy(dst, src, sizeof(Uint32));
+                src += sizeof(Uint32);
+                dst += sizeof(Uint32);
             , width);
             /* *INDENT-ON* */
-            src = (const Uint32 *)((const Uint8 *)src + srcskip);
+            src += srcskip;
             dst = (Uint32 *)((Uint8 *)dst + dstskip);
         }
     } else {
@@ -480,7 +482,8 @@ static void BG_Blended_Color(const TTF_Image *image, Uint32 *destination, Sint32
             DUFFS_LOOP4(
                     /* prevent misaligned load: tmp = *src++; */
                     // eventually, we can expect the compiler to replace the memcpy call with something optimized
-                    SDL_memcpy(&tmp, src++, sizeof(tmp));
+                    SDL_memcpy(&tmp, src, sizeof(tmp));
+                    src += sizeof(Uint32);
                     alpha = tmp >> 24;
                     tmp &= ~0xFF000000;
                     alpha = fg_alpha * alpha;
@@ -488,7 +491,7 @@ static void BG_Blended_Color(const TTF_Image *image, Uint32 *destination, Sint32
                     *dst++ = tmp | alpha
                     , width);
             /* *INDENT-ON* */
-            src = (const Uint32 *)((const Uint8 *)src + srcskip);
+            src += srcskip;
             dst = (Uint32 *)((Uint8 *)dst + dstskip);
         }
     }
@@ -497,7 +500,7 @@ static void BG_Blended_Color(const TTF_Image *image, Uint32 *destination, Sint32
 // Blend with LCD rendering
 static void BG_Blended_LCD(const TTF_Image *image, Uint32 *destination, Sint32 srcskip, Uint32 dstskip, SDL_Color *fg)
 {
-    const Uint32 *src   = (Uint32 *)image->buffer;
+    const Uint8 *src    = image->buffer;
     Uint32      *dst    = destination;
     Uint32       width  = image->width;
     Uint32       height = image->rows;
@@ -515,8 +518,8 @@ static void BG_Blended_LCD(const TTF_Image *image, Uint32 *destination, Sint32 s
     while (height--) {
         /* *INDENT-OFF* */
         DUFFS_LOOP4(
-                /* prevent misaligned load: tmp = *src++; */
-                SDL_memcpy(&tmp, src++, sizeof(tmp));
+                SDL_memcpy(&tmp, src, sizeof(tmp));
+                src += sizeof(Uint32);
 
                 if (tmp) {
                     bg = *dst;
@@ -549,7 +552,7 @@ static void BG_Blended_LCD(const TTF_Image *image, Uint32 *destination, Sint32 s
 
                 , width);
         /* *INDENT-ON* */
-        src = (const Uint32 *)((const Uint8 *)src + srcskip);
+        src += srcskip;
         dst = (Uint32 *)((Uint8 *)dst + dstskip);
     }
 
@@ -647,10 +650,18 @@ static void BG_Blended_32(const TTF_Image *image, Uint32 *destination, Sint32 sr
 #endif
 
 #if defined(HAVE_SSE2_INTRINSICS)
+
+// This does an unaligned SIMD load, the pointer cast is technically UB but no compiler
+// probably actually cares as long as the alignment sanitizer is disabled, the wrapper is
+// necessary to have the smallest surface where the sanitizer is turned off
+static inline __m128i __attribute__((no_sanitize("alignment"))) _mm_loadu_si128_unaligned(const void *ptr) {
+    return _mm_loadu_si128(ptr);
+}
+
 // Apply: alpha_table[i] = i << 24;
 static void BG_Blended_Opaque_SSE(const TTF_Image *image, Uint32 *destination, Sint32 srcskip, Uint32 dstskip)
 {
-    const __m128i *src    = (__m128i *)image->buffer;
+    const Uint8   *src    = image->buffer;
     __m128i       *dst    = (__m128i *)destination;
     Uint32         width  = image->width / 16;
     Uint32         height = image->rows;
@@ -662,7 +673,7 @@ static void BG_Blended_Opaque_SSE(const TTF_Image *image, Uint32 *destination, S
         /* *INDENT-OFF* */
         DUFFS_LOOP4(
             // Read 16 Uint8 at once and put into 4 __m128i
-            s  = _mm_loadu_si128(src);          // load unaligned
+            s  = _mm_loadu_si128_unaligned(src);// load unaligned
             d0 = _mm_load_si128(dst);           // load
             d1 = _mm_load_si128(dst + 1);       // load
             d2 = _mm_load_si128(dst + 2);       // load
@@ -687,17 +698,17 @@ static void BG_Blended_Opaque_SSE(const TTF_Image *image, Uint32 *destination, S
             _mm_store_si128(dst + 3, r3);       // store
 
             dst += 4;
-            src += 1;
+            src += sizeof(__m128i);
         , width);
         /* *INDENT-ON* */
-        src = (const __m128i *)((const Uint8 *)src + srcskip);
+        src += srcskip;
         dst = (__m128i *)((Uint8 *)dst + dstskip);
     }
 }
 
 static void BG_Blended_SSE(const TTF_Image *image, Uint32 *destination, Sint32 srcskip, Uint32 dstskip, Uint8 fg_alpha)
 {
-    const __m128i *src    = (__m128i *)image->buffer;
+    const Uint8   *src    = image->buffer;
     __m128i       *dst    = (__m128i *)destination;
     Uint32         width  = image->width / 16;
     Uint32         height = image->rows;
@@ -711,7 +722,7 @@ static void BG_Blended_SSE(const TTF_Image *image, Uint32 *destination, Sint32 s
         /* *INDENT-OFF* */
         DUFFS_LOOP4(
             // Read 16 Uint8 at once and put into 4 __m128i
-            s  = _mm_loadu_si128(src);          // load unaligned
+            s  = _mm_loadu_si128_unaligned(src);// load unaligned
             d0 = _mm_load_si128(dst);           // load
             d1 = _mm_load_si128(dst + 1);       // load
             d2 = _mm_load_si128(dst + 2);       // load
@@ -755,10 +766,10 @@ static void BG_Blended_SSE(const TTF_Image *image, Uint32 *destination, Sint32 s
             _mm_store_si128(dst + 3, r3);       // store
 
             dst += 4;
-            src += 1;
+            src += sizeof(__m128i);
         , width);
         /* *INDENT-ON* */
-        src = (const __m128i *)((const Uint8 *)src + srcskip);
+        src += srcskip;
         dst = (__m128i *)((Uint8 *)dst + dstskip);
     }
 }
@@ -910,7 +921,7 @@ static void BG(const TTF_Image *image, Uint8 *destination, Sint32 srcskip, Uint3
 #if defined(HAVE_BLIT_GLYPH_64)
 static void BG_64(const TTF_Image *image, Uint8 *destination, Sint32 srcskip, Uint32 dstskip)
 {
-    const Uint64 *src    = (Uint64 *)image->buffer;
+    const Uint8  *src    = image->buffer;
     Uint64       *dst    = (Uint64 *)destination;
     Uint32        width  = image->width / 8;
     Uint32        height = image->rows;
@@ -920,18 +931,19 @@ static void BG_64(const TTF_Image *image, Uint8 *destination, Sint32 srcskip, Ui
         /* *INDENT-OFF* */
         DUFFS_LOOP4(
               /* prevent misaligned load: *dst++ |= *src++; */
-              SDL_memcpy(&tmp, src++, sizeof(tmp));
+              SDL_memcpy(&tmp, src, sizeof(tmp));
+              src += sizeof(Uint64);
               *dst++ |= tmp;
         , width);
         /* *INDENT-ON* */
-        src = (const Uint64 *)((const Uint8 *)src + srcskip);
+        src += srcskip;
         dst = (Uint64 *)((Uint8 *)dst + dstskip);
     }
 }
 #elif defined(HAVE_BLIT_GLYPH_32)
 static void BG_32(const TTF_Image *image, Uint8 *destination, Sint32 srcskip, Uint32 dstskip)
 {
-    const Uint32 *src    = (Uint32 *)image->buffer;
+    const Uint8  *src    = image->buffer;
     Uint32       *dst    = (Uint32 *)destination;
     Uint32        width  = image->width / 4;
     Uint32        height = image->rows;
@@ -941,11 +953,12 @@ static void BG_32(const TTF_Image *image, Uint8 *destination, Sint32 srcskip, Ui
         /* *INDENT-OFF* */
         DUFFS_LOOP4(
             /* prevent misaligned load: *dst++ |= *src++; */
-            SDL_memcpy(&tmp, src++, sizeof(tmp));
+            SDL_memcpy(&tmp, src, sizeof(tmp));
+            src += sizeof(Uint32);
             *dst++ |= tmp;
         , width);
         /* *INDENT-ON* */
-        src = (const Uint32 *)((const Uint8 *)src + srcskip);
+        src += srcskip;
         dst = (Uint32 *)((Uint8 *)dst + dstskip);
     }
 }
@@ -954,7 +967,7 @@ static void BG_32(const TTF_Image *image, Uint8 *destination, Sint32 srcskip, Ui
 #if defined(HAVE_SSE2_INTRINSICS)
 static void BG_SSE(const TTF_Image *image, Uint8 *destination, Sint32 srcskip, Uint32 dstskip)
 {
-    const __m128i *src    = (__m128i *)image->buffer;
+    const Uint8   *src    = image->buffer;
     __m128i       *dst    = (__m128i *)destination;
     Uint32         width  = image->width / 16;
     Uint32         height = image->rows;
@@ -964,15 +977,15 @@ static void BG_SSE(const TTF_Image *image, Uint8 *destination, Sint32 srcskip, U
     while (height--) {
         /* *INDENT-OFF* */
         DUFFS_LOOP4(
-            s = _mm_loadu_si128(src);   // load unaligned
+            s = _mm_loadu_si128_unaligned(src);   // load unaligned
             d = _mm_load_si128(dst);    // load
             r = _mm_or_si128(d, s);     // or
             _mm_store_si128(dst, r);    // store
-            src += 1;
+            src += sizeof(__m128i);
             dst += 1;
         , width);
         /* *INDENT-ON* */
-        src = (const __m128i *)((const Uint8 *)src + srcskip);
+        src += srcskip;
         dst = (__m128i *)((Uint8 *)dst + dstskip);
     }
 }
@@ -999,7 +1012,7 @@ static void BG_NEON(const TTF_Image *image, Uint8 *destination, Sint32 srcskip, 
             dst += 16;
         , width);
         /* *INDENT-ON* */
-        src = (const Uint8 *)((const Uint8 *)src + srcskip);
+        src += srcskip;
         dst += dstskip;
     }
 }
@@ -1160,6 +1173,10 @@ static int Get_Alignment(void)
 #endif
 }
 
+// Depending on the architecture, the SIMD implementations of Glyph Blitting functions may not
+// work if srcskip/dstskip is not a multiple of 16, if this is the case, set this define to 0
+#define ALLOW_MISALIGNED_SIMD 1
+
 #ifdef __GNUC__
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-value"
@@ -1225,12 +1242,22 @@ static bool Render_Line_##NAME(TTF_Font *font, SDL_Surface *textbuf, int xstart,
                     dstskip = textbuf->pitch - image->width * bpp;                                                      \
                     BG_Blended_LCD(image, (Uint32 *)dst, srcskip, dstskip, fg);                                         \
                 } else if (!IS_BLENDED || image->is_color == 0) {                                                       \
-                    if (IS_BLENDED_OPAQUE) {                                                                            \
-                        BLIT_GLYPH_BLENDED_OPAQUE_OPTIM(image, (Uint32 *)dst, srcskip, dstskip);                        \
-                    } else if (IS_BLENDED) {                                                                            \
-                        BLIT_GLYPH_BLENDED_OPTIM(image, (Uint32 *)dst, srcskip, dstskip, fg_alpha);                     \
-                    } else if (image->is_color == 0) {                                                                                            \
-                        BLIT_GLYPH_OPTIM(image, dst, srcskip, dstskip);                                                 \
+                    if (ALLOW_MISALIGNED_SIMD || ((srcskip & alignment) == 0 && (dstskip & alignment) == 0)) {          \
+                        if (IS_BLENDED_OPAQUE) {                                                                        \
+                            BLIT_GLYPH_BLENDED_OPAQUE_OPTIM(image, (Uint32 *)dst, srcskip, dstskip);                    \
+                        } else if (IS_BLENDED) {                                                                        \
+                            BLIT_GLYPH_BLENDED_OPTIM(image, (Uint32 *)dst, srcskip, dstskip, fg_alpha);                 \
+                        } else if (image->is_color == 0) {                                                              \
+                            BLIT_GLYPH_OPTIM(image, dst, srcskip, dstskip);                                             \
+                        }                                                                                               \
+                    } else {                                                                                            \
+                        if (IS_BLENDED_OPAQUE) {                                                                        \
+                            BG_Blended_Opaque(image, (Uint32 *)dst, srcskip, dstskip);                                  \
+                        } else if (IS_BLENDED) {                                                                        \
+                            BG_Blended(image, (Uint32 *)dst, srcskip, dstskip, fg_alpha);                               \
+                        } else if (image->is_color == 0) {                                                              \
+                            BG(image, dst, srcskip, dstskip);                                                           \
+                        }                                                                                               \
                     }                                                                                                   \
                 } else if (IS_BLENDED && image->is_color) {                                                             \
                     image->buffer = saved_buffer;                                                                       \


### PR DESCRIPTION
The BG_Blended_LCD function uses Uint32 pointers to keep track of source and destination but this can cause undefined behavior if src becomes misaligned. This can happen is `srcskip` is not a multiple of `sizeof(Uint32)`. This is why the function uses `SDL_memcpy` for reading the `src` buffer.

But it is actually undefined behavior to even perform the cast on line 552 when the result is misaligned. The error is caught at runtime with ubsan in debug mode (I found it compiling with `zig` so it can also probably be found with `clang`).

From the C11 standard (C11 (n1570) 6.3.2.3 p7)
```
A pointer to an object type may be converted to a pointer to a different object type. If the
resulting pointer is not correctly aligned68) for the referenced type, the behavior is
undefined.
```

This patch makes the pointer a byte pointers and makes the increment sizes explicit.

There may be a similar problem with `dst` / `dskskip`  but it looks like they are always aligned in the current implementation, (as long as the image pitch is). Maybe an assertion could be added for future proofing.