### PR TITLE
Return the errors from GetWrappedLines in LayoutText instead of ignoring them

### DIFF
--- a/src/SDL_ttf.c
+++ b/src/SDL_ttf.c
@@ -4512,7 +4512,7 @@ static bool LayoutText(TTF_Text *text)
     Uint32 script = TTF_GetTextScript(text);
 
     if (!GetWrappedLines(font, text->text, length, direction, script, text->internal->x, wrap_width, trim_whitespace, &strLines, &numLines, &width, &height, false)) {
-        return true;
+        return false;
     }
     height += text->internal->y;
 


### PR DESCRIPTION
`GetWrappedLines` can return with a bunch of errors and `LayoutText` was previously ignoring them by returning `true`.

I stumbled into this when I made a mistake misusing the API, that caused TrueType to return an error somewhere deep into the call stack of SDL_ttf. Before the patch, that error was not showing up, instead the text was silently not being rendered.