### PR TITLE
Fix potential memory leak when text engine texture atlas is invalid

### DIFF
--- a/src/SDL_gpu_textengine.c
+++ b/src/SDL_gpu_textengine.c
@@ -981,6 +981,7 @@ TTF_TextEngine *TTF_CreateGPUTextEngineWithProperties(SDL_PropertiesID props)
     int atlas_texture_size = (int)SDL_GetNumberProperty(props, TTF_PROP_GPU_TEXT_ENGINE_ATLAS_TEXTURE_SIZE_NUMBER, 1024);
     if (atlas_texture_size <= 0) {
         SDL_SetError("Failed to create GPU text engine: Invalid texture atlas size.");
+        SDL_free(engine);
         return NULL;
     }
 

--- a/src/SDL_renderer_textengine.c
+++ b/src/SDL_renderer_textengine.c
@@ -887,6 +887,7 @@ TTF_TextEngine *TTF_CreateRendererTextEngineWithProperties(SDL_PropertiesID prop
     }
     if (atlas_texture_size <= 0) {
         SDL_SetError("Failed to create renderer text engine: Invalid texture atlas size.");
+        SDL_free(engine);
         return NULL;
     }
 


### PR DESCRIPTION
Freeing `engine` when the texture atlas size is invalid.


<details><summary>Warning 1</summary>
<p>

```c
/path/to/SDL_ttf/src/SDL_gpu_textengine.c:983:9: warning: Potential leak of memory pointed to by 'engine' [clang-analyzer-unix.Malloc]
  983 |         SDL_SetError("Failed to create GPU text engine: Invalid texture atlas size.");
      |         ^
/path/to/SDL_ttf/src/SDL_gpu_textengine.c:959:9: note: Assuming 'props' is not equal to 0
  959 |     if (props == 0) {
      |         ^~~~~~~~~~
/path/to/SDL_ttf/src/SDL_gpu_textengine.c:959:5: note: Taking false branch
  959 |     if (props == 0) {
      |     ^
/path/to/SDL_ttf/src/SDL_gpu_textengine.c:965:12: note: Calling 'TTF_CreateGPUTextEngineWithProperties'
  965 |     return TTF_CreateGPUTextEngineWithProperties(props);
      |            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/path/to/SDL_ttf/src/SDL_gpu_textengine.c:971:9: note: Assuming 'device' is non-null
  971 |     if (!device) {
      |         ^~~~~~~
/path/to/SDL_ttf/src/SDL_gpu_textengine.c:971:5: note: Taking false branch
  971 |     if (!device) {
      |     ^
/path/to/SDL_ttf/src/SDL_gpu_textengine.c:976:48: note: Memory is allocated
  976 |     TTF_TextEngine *engine = (TTF_TextEngine *)SDL_malloc(sizeof(*engine));
      |                                                ^
/path/to/SDL/Linux/Linux/gcc/Debug/include/SDL3/SDL_stdinc.h:5989:20: note: expanded from macro 'SDL_malloc'
 5989 | #define SDL_malloc malloc
      |                    ^
/path/to/SDL_ttf/src/SDL_gpu_textengine.c:977:9: note: Assuming 'engine' is non-null
  977 |     if (!engine) {
      |         ^~~~~~~
/path/to/SDL_ttf/src/SDL_gpu_textengine.c:977:5: note: Taking false branch
  977 |     if (!engine) {
      |     ^
/path/to/SDL_ttf/src/SDL_gpu_textengine.c:982:9: note: Assuming 'atlas_texture_size' is <= 0
  982 |     if (atlas_texture_size <= 0) {
      |         ^~~~~~~~~~~~~~~~~~~~~~~
/path/to/SDL_ttf/src/SDL_gpu_textengine.c:982:5: note: Taking true branch
  982 |     if (atlas_texture_size <= 0) {
      |     ^
/path/to/SDL_ttf/src/SDL_gpu_textengine.c:983:9: note: Potential leak of memory pointed to by 'engine'
  983 |         SDL_SetError("Failed to create GPU text engine: Invalid texture atlas size.");
      |         ^
```

</p>
</details> 

<details><summary>Warning 2</summary>
<p>

```c
/path/to/SDL_ttf/src/SDL_renderer_textengine.c:889:9: warning: Potential leak of memory pointed to by 'engine' [clang-analyzer-unix.Malloc]
  889 |         SDL_SetError("Failed to create renderer text engine: Invalid texture atlas size.");
      |         ^
/path/to/SDL_ttf/src/SDL_renderer_textengine.c:861:9: note: Assuming 'props' is not equal to 0
  861 |     if (props == 0) {
      |         ^~~~~~~~~~
/path/to/SDL_ttf/src/SDL_renderer_textengine.c:861:5: note: Taking false branch
  861 |     if (props == 0) {
      |     ^
/path/to/SDL_ttf/src/SDL_renderer_textengine.c:867:12: note: Calling 'TTF_CreateRendererTextEngineWithProperties'
  867 |     return TTF_CreateRendererTextEngineWithProperties(props);
      |            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/path/to/SDL_ttf/src/SDL_renderer_textengine.c:873:9: note: Assuming 'renderer' is non-null
  873 |     if (!renderer) {
      |         ^~~~~~~~~
/path/to/SDL_ttf/src/SDL_renderer_textengine.c:873:5: note: Taking false branch
  873 |     if (!renderer) {
      |     ^
/path/to/SDL_ttf/src/SDL_renderer_textengine.c:878:48: note: Memory is allocated
  878 |     TTF_TextEngine *engine = (TTF_TextEngine *)SDL_malloc(sizeof(*engine));
      |                                                ^
/path/to/SDL/Linux/Linux/gcc/Debug/include/SDL3/SDL_stdinc.h:5989:20: note: expanded from macro 'SDL_malloc'
 5989 | #define SDL_malloc malloc
      |                    ^
/path/to/SDL_ttf/src/SDL_renderer_textengine.c:879:9: note: Assuming 'engine' is non-null
  879 |     if (!engine) {
      |         ^~~~~~~
/path/to/SDL_ttf/src/SDL_renderer_textengine.c:879:5: note: Taking false branch
  879 |     if (!engine) {
      |     ^
/path/to/SDL_ttf/src/SDL_renderer_textengine.c:885:9: note: Assuming 'max_atlas_texture_size' is 0
  885 |     if (max_atlas_texture_size && atlas_texture_size > max_atlas_texture_size) {
      |         ^~~~~~~~~~~~~~~~~~~~~~
/path/to/SDL_ttf/src/SDL_renderer_textengine.c:885:32: note: Left side of '&&' is false
  885 |     if (max_atlas_texture_size && atlas_texture_size > max_atlas_texture_size) {
      |                                ^
/path/to/SDL_ttf/src/SDL_renderer_textengine.c:888:9: note: Assuming 'atlas_texture_size' is <= 0
  888 |     if (atlas_texture_size <= 0) {
      |         ^~~~~~~~~~~~~~~~~~~~~~~
/path/to/SDL_ttf/src/SDL_renderer_textengine.c:888:5: note: Taking true branch
  888 |     if (atlas_texture_size <= 0) {
      |     ^
/path/to/SDL_ttf/src/SDL_renderer_textengine.c:889:9: note: Potential leak of memory pointed to by 'engine'
  889 |         SDL_SetError("Failed to create renderer text engine: Invalid texture atlas size.");
      |         ^
```

</p>
</details> 