### PR TITLE
Implement TTF_SetFontCharSpacing()

### DIFF
--- a/examples/showfont.c
+++ b/examples/showfont.c
@@ -261,6 +261,18 @@ static void HandleKeyDown(Scene *scene, SDL_Event *event)
         }
         break;
 
+    case SDLK_COMMA:
+        if (event->key.mod & SDL_KMOD_CTRL) {
+            TTF_SetFontCharSpacing(scene->font, TTF_GetFontCharSpacing(scene->font) - 1);
+        }
+        break;
+
+    case SDLK_PERIOD:
+        if (event->key.mod & SDL_KMOD_CTRL) {
+            TTF_SetFontCharSpacing(scene->font, TTF_GetFontCharSpacing(scene->font) + 1);
+        }
+        break;
+
     case SDLK_ESCAPE:
         scene->done = true;
         break;

--- a/include/SDL3_ttf/SDL_ttf.h
+++ b/include/SDL3_ttf/SDL_ttf.h
@@ -1003,7 +1003,7 @@ extern SDL_DECLSPEC bool SDLCALL TTF_SetFontCharSpacing(TTF_Font *font, int spac
  * \threadsafety This function should be called on the thread that created the
  *               font.
  *
- * \since This function is available since SDL_ttf 3.0.0.
+ * \since This function is available since SDL_ttf 3.4.0.
  */
 extern SDL_DECLSPEC int SDLCALL TTF_GetFontCharSpacing(TTF_Font *font);
 

--- a/include/SDL3_ttf/SDL_ttf.h
+++ b/include/SDL3_ttf/SDL_ttf.h
@@ -987,7 +987,7 @@ extern SDL_DECLSPEC TTF_Direction SDLCALL TTF_GetFontDirection(TTF_Font *font);
  * \threadsafety This function should be called on the thread that created the
  *               font.
  *
- * \since This function is available since SDL_ttf 3.0.0.
+ * \since This function is available since SDL_ttf 3.4.0.
  */
 extern SDL_DECLSPEC bool SDLCALL TTF_SetFontCharSpacing(TTF_Font *font, int spacing);
 

--- a/include/SDL3_ttf/SDL_ttf.h
+++ b/include/SDL3_ttf/SDL_ttf.h
@@ -970,6 +970,44 @@ extern SDL_DECLSPEC bool SDLCALL TTF_SetFontDirection(TTF_Font *font, TTF_Direct
 extern SDL_DECLSPEC TTF_Direction SDLCALL TTF_GetFontDirection(TTF_Font *font);
 
 /**
+ * Set additional space in pixels to be applied between any two rendered
+ * characters. The spacing value is applied uniformly after each character,
+ * in addition to the normal glyph's advance.
+ * 
+ * Spacing may be a negative value, in which case it will reduce the
+ * distance instead.
+ *
+ * This updates any TTF_Text objects using this font.
+ *
+ * \param font the font to specify a direction for.
+ * \param char_spacing the new spacing value.
+ * \returns true on success or false on failure; call SDL_GetError() for more
+ *          information.
+ *
+ * \threadsafety This function should be called on the thread that created the
+ *               font.
+ *
+ * \since This function is available since SDL_ttf 3.0.0.
+ */
+extern SDL_DECLSPEC bool SDLCALL TTF_SetFontCharSpacing(TTF_Font *font, int spacing);
+
+/**
+ * Get the additional character spacing in pixels to be applied between any two
+ * rendered characters.
+ *
+ * This defaults to 0 if it hasn't been set.
+ *
+ * \param font the font to query.
+ * \returns the character spacing in pixels.
+ *
+ * \threadsafety This function should be called on the thread that created the
+ *               font.
+ *
+ * \since This function is available since SDL_ttf 3.0.0.
+ */
+extern SDL_DECLSPEC int SDLCALL TTF_GetFontCharSpacing(TTF_Font *font);
+
+/**
  * Convert from a 4 character string to a 32-bit tag.
  *
  * \param string the 4 character string to convert.

--- a/src/SDL_ttf.sym
+++ b/src/SDL_ttf.sym
@@ -117,5 +117,7 @@ SDL3_ttf_0.0.0 {
     TTF_UpdateText;
     TTF_Version;
     TTF_WasInit;
+    TTF_SetFontCharSpacing;
+    TTF_GetFontCharSpacing;
   local: *;
 };


### PR DESCRIPTION
Resolves #561

This is an experimental proposal, which adds an optional uniform character spacing, applied after each drawn glyph *in addition* to the normal glyph's advance. Spacing may be both positive or negative. Setting this to 0 ensures that the font is drawn using only its kerning.

Two new functions declared as:
```
bool TTF_SetFontCharSpacing(TTF_Font *font, int char_spacing);
int TTF_GetFontCharSpacing(TTF_Font *font);
```

Character spacing value is in pixels on input, but stored as a 26.6 FP in the TTF_Font struct, for compatibility with GlyphPosition's fields. When calculating glyph positions, "char_spacing" is added to each pos's x_advance.

Additionally, added two new key controls to the "showfont" example:
Ctrl + , - decreases character spacing
Ctrl + . - increases character spacing
