### PR TITLE
Implement TTF_GetFontBBox() which returns font's extremum bounding box

### DIFF
--- a/include/SDL3_ttf/SDL_ttf.h
+++ b/include/SDL3_ttf/SDL_ttf.h
@@ -845,6 +845,33 @@ extern SDL_DECLSPEC void SDLCALL TTF_SetFontKerning(TTF_Font *font, bool enabled
 extern SDL_DECLSPEC bool SDLCALL TTF_GetFontKerning(const TTF_Font *font);
 
 /**
+ * Query the font's bounding box.
+ *
+ * The bounding box defines bounds large enough to contain any glyph from
+ * the font. It is expressed in pixel offsets from glyph's origin (0,0),
+ * with Y axis pointing upwards. Thus maxy offset may be seen as the
+ * "maximum ascender" and miny offset - as the "minimum descender".
+ *
+ * \param font the font to query.
+ * \param minx a pointer filled in with the minimum x coordinate of *any* glyph
+ *             in this font from it's origin. This value may be negative.
+ * \param maxx a pointer filled in with the maximum x coordinate of *any* glyph
+ *             in this font from it's origin.
+ * \param miny a pointer filled in with the minimum y coordinate of *any* glyph
+ *             in this font from it's origin. This value may be negative.
+ * \param maxy a pointer filled in with the maximum y coordinate of *any* glyph
+ *             in this font from it's origin.
+ * \returns true on success or false on failure; call SDL_GetError() for more
+ *          information.
+ *
+ * \threadsafety This function should be called on the thread that created the
+ *               font.
+ *
+ * \since This function is available since SDL_ttf 3.4.0.
+ */
+extern SDL_DECLSPEC bool SDLCALL TTF_GetFontBBox(const TTF_Font *font, int *minx, int *maxx, int *miny, int *maxy);
+
+/**
  * Query whether a font is fixed-width.
  *
  * A "fixed-width" font means all glyphs are the same width across; a

--- a/src/SDL_ttf.c
+++ b/src/SDL_ttf.c
@@ -5915,6 +5915,34 @@ bool TTF_GetFontKerning(const TTF_Font *font)
     return font->enable_kerning;
 }
 
+bool TTF_GetFontBBox(const TTF_Font *font, int *minx, int *maxx, int *miny, int *maxy)
+{
+    TTF_CHECK_FONT(font, false);
+
+    /* Bitmap fonts do not contain bbox information */
+    if (!FT_IS_SCALABLE(font->face)) {
+        return false;
+    }
+
+    const FT_Face face = font->face;
+    /* Recalculate FT_Face's bbox from font units to pixels */
+    FT_Fixed xscale = face->size->metrics.x_scale;
+    FT_Fixed yscale = face->size->metrics.y_scale;
+    if (minx) {
+        *minx = FT_CEIL(FT_MulFix(face->bbox.xMin, xscale));
+    }
+    if (maxx) {
+        *maxx = FT_CEIL(FT_MulFix(face->bbox.xMax, xscale));
+    }
+    if (miny) {
+        *miny = FT_CEIL(FT_MulFix(face->bbox.yMin, yscale));
+    }
+    if (maxy) {
+        *maxy = FT_CEIL(FT_MulFix(face->bbox.yMax, yscale));
+    }
+    return true;
+}
+
 int TTF_GetNumFontFaces(const TTF_Font *font)
 {
     TTF_CHECK_FONT(font, 0);

--- a/src/SDL_ttf.sym
+++ b/src/SDL_ttf.sym
@@ -119,5 +119,6 @@ SDL3_ttf_0.0.0 {
     TTF_WasInit;
     TTF_SetFontCharSpacing;
     TTF_GetFontCharSpacing;
+    TTF_GetFontBBox;
   local: *;
 };


### PR DESCRIPTION
Resolves #536
(This is a remake of #538 ported to SDL3-backed branch)

This adds a new function called TTF_GetFontBBox:
```
bool TTF_GetFontBBox(const TTF_Font *font, int *minx, int *maxx, int *miny, int *maxy);
```

This function returns font's bounding box, which defines the maximal bounds enough to contain *any* glyph from the font.
My understanding is this information is only available when reading the scalable font formats, so for non-scalable fonts this function always returns "false". (If that's wrong, then the function may be trivially updated to cover bitmap fonts as well.)

TTF_GetFontBBox complements TTF_GetGlyphMetrics, and is useful in a case when you need to know max possible bounds instead of particular glyph's bounds. The "bbox" information is available in the format header, thus it can be obtained without measuring every single glyph.

Since I was previously asked to explain use cases for this function, here are couple of real examples from my practice:
1. You want to get a rectangle suitable for any glyph from this font, for example, when displaying a font's preview as a table (grid) with all glyphs arranged evenly.
2. Some rare fonts have wrong info about their ascent and descent, which results in them reporting inaccurate or just nonsensical height value. Getting bbox may help in such case, if we compare their Y extent with height and choose whatever is bigger. This helps if we need to precreate a drawing surface where we print this text, or arrange objects on screen if their positions are based on the actual text size. I know that you can get text measurements when you have a text, but sometimes we want to do these calculations before any text is displayed (or when it is not known *what* text will be displayed).
