### PR TITLE
fix crash dereferencing text->internal->engine before checking

### DIFF
--- a/src/SDL_surface_textengine.c
+++ b/src/SDL_surface_textengine.c
@@ -332,7 +332,7 @@ static void DrawCopy(TTF_SurfaceTextEngineTextData *data, const TTF_CopyOperatio
 
 bool TTF_DrawSurfaceText(TTF_Text *text, int x, int y, SDL_Surface *surface)
 {
-    if (!text || !text->internal || text->internal->engine->CreateText != CreateText) {
+    if (!text || !text->internal || !text->internal->engine || text->internal->engine->CreateText != CreateText) {
         return SDL_InvalidParamError("text");
     }
     if (!surface) {


### PR DESCRIPTION

This fixes: https://github.com/libsdl-org/SDL_ttf/issues/589

It looks like this commit:
https://github.com/libsdl-org/SDL_ttf/commit/25b596c820a1377cdf7fccbcfc1e0399705d5e5c

changed `text->engine` to `text->internal->engine` but did not add new check for `text->internal->engine`