### PR TITLE
Correct migration guide for TTF_SizeText/TTF_SizeUTF8

### DIFF
--- a/docs/README-migration.md
+++ b/docs/README-migration.md
@@ -67,8 +67,8 @@ The following functions have been renamed:
 * TTF_RenderUTF8_Solid_Wrapped() => TTF_RenderText_Solid_Wrapped()
 * TTF_SetFontScriptName() => TTF_SetFontScript()
 * TTF_SetFontWrappedAlign() => TTF_SetFontWrapAlignment()
-* TTF_SizeText() => TTF_GetTextSize()
-* TTF_SizeUTF8() => TTF_GetTextSize()
+* TTF_SizeText() => TTF_GetStringSize()
+* TTF_SizeUTF8() => TTF_GetStringSize()
 
 The following functions have been removed:
 * TTF_ByteSwappedUNICODE()


### PR DESCRIPTION
According to the .cocci file, they both get replaced by TTF_GetStringSize(), which matches their signatures (aside from the return type) and makes it a simple rename.