### PR TITLE
Fix genexports.py documentation warnings

### DIFF
--- a/include/SDL3_ttf/SDL_ttf.h
+++ b/include/SDL3_ttf/SDL_ttf.h
@@ -982,6 +982,7 @@ extern SDL_DECLSPEC TTF_Direction SDLCALL TTF_GetFontDirection(TTF_Font *font);
  * This updates any TTF_Text objects using this font.
  *
  * \param font the font to specify a direction for.
+ * \param spacing the new additional glyph spacing for the font.
  * \returns true on success or false on failure; call SDL_GetError() for more
  *          information.
  *
@@ -2370,6 +2371,8 @@ extern SDL_DECLSPEC bool SDLCALL TTF_GetTextColorFloat(TTF_Text *text, float *r,
  * \param text the TTF_Text to modify.
  * \param x the x offset of the upper left corner of this text in pixels.
  * \param y the y offset of the upper left corner of this text in pixels.
+ * \returns true on success or false on failure; call SDL_GetError() for more
+ *          information.
  *
  * \threadsafety This function should be called on the thread that created the
  *               text.
@@ -2388,6 +2391,8 @@ extern SDL_DECLSPEC bool SDLCALL TTF_SetTextPosition(TTF_Text *text, int x, int 
  *          this text in pixels, may be NULL.
  * \param y a pointer filled in with the y offset of the upper left corner of
  *          this text in pixels, may be NULL.
+ * \returns true on success or false on failure; call SDL_GetError() for more
+ *          information.
  *
  * \threadsafety This function should be called on the thread that created the
  *               text.


### PR DESCRIPTION
Fix these `genexports.py` warnings:
```
[WARNING] 
[WARNING] Please fix following warning(s):
[WARNING] --------------------------------
[WARNING]   In file SDL_ttf.h: function TTF_SetFontCharSpacing() has 1 '\param' but expected 2
[WARNING]   In file SDL_ttf.h: function TTF_SetFontCharSpacing() missing '\param spacing'
[WARNING]   In file SDL_ttf.h: function TTF_SetTextPosition() has 0 '\returns' but expected 1
[WARNING]   In file SDL_ttf.h: function TTF_GetTextPosition() has 0 '\returns' but expected 1
```