### PR TITLE
Fix memcpy misuse in TTF_DeleteTextString

### DIFF
--- a/src/SDL_ttf.c
+++ b/src/SDL_ttf.c
@@ -5065,7 +5065,7 @@ bool TTF_DeleteTextString(TTF_Text *text, int offset, int length)
         text->text[offset] = '\0';
     } else {
         int shift = (old_length - length - offset);
-        SDL_memcpy(&text->text[offset], &text->text[offset + length], shift);
+        SDL_memmove(&text->text[offset], &text->text[offset + length], shift);
         text->text[offset + shift] = '\0';
     }
 


### PR DESCRIPTION
AddressSanitizer aborts the program when calling `TTF_DeleteTextString`, which in turn calls `SDL_memcpy` instead of the correct `SDL_memmove`.

This commit fixes the abort under ASan.