### PR TITLE
Text clipping math fix

### DIFF
--- a/src/SDL_ttf.c
+++ b/src/SDL_ttf.c
@@ -1464,8 +1464,8 @@ static bool Render_Line_TextEngine(TTF_Font *font, TTF_Direction direction, int 
 
         if (!glyph_font->render_sdf) {
             // Make sure glyph is inside text area
-            above_w = x + glyph_width - width;
-            above_h = y + glyph_rows  - height;
+            above_w = x + glyph_width - (xstart + width);
+            above_h = y + glyph_rows  - (ystart + height);
 
             if (x < 0) {
                 int tmp = -x;


### PR DESCRIPTION
Updated calculation for text clipping within `Render_Line_TextEngine` to account for text with non-zero position (see related issue). 

Fixes #603 