### PR TITLE
Flush cache when removing a fallback font (fix #549)

### DIFF
--- a/src/SDL_ttf.c
+++ b/src/SDL_ttf.c
@@ -2332,6 +2332,8 @@ bool TTF_AddFallbackFont(TTF_Font *font, TTF_Font *fallback)
     return true;
 }
 
+static void Flush_Cache(TTF_Font *font);
+
 void TTF_RemoveFallbackFont(TTF_Font *font, TTF_Font *fallback)
 {
     if (!font || !fallback) {
@@ -2364,6 +2366,7 @@ void TTF_RemoveFallbackFont(TTF_Font *font, TTF_Font *fallback)
         }
     }
 
+    Flush_Cache(font);
     UpdateFontText(font, NULL);
 }
 


### PR DESCRIPTION
If a fallback font is closed, the main font's cache may still have a GlyphPosition pointing to the fallback font.
This will lead to a crash when rendering a text that is still in the cache.

This PR simply flushes the font's cache when a fallback is removed.