### PR TITLE
fixed: sdf character layout was misaligned

### DIFF
--- a/src/SDL_ttf.c
+++ b/src/SDL_ttf.c
@@ -1504,8 +1504,6 @@ static bool Render_Line_TextEngine(TTF_Font *font, TTF_Direction direction, int 
             if (glyph_font->render_sdf) {
                 op->copy.dst.x -= DEFAULT_SDF_SPREAD;
                 op->copy.dst.y -= DEFAULT_SDF_SPREAD;
-                op->copy.dst.w -= DEFAULT_SDF_SPREAD;
-                op->copy.dst.h -= DEFAULT_SDF_SPREAD;
             }
         } else {
             // Use the distance to the next glyph as our bounds width


### PR DESCRIPTION
The glyphs were misaligned when rendering sdf text (at least with `TTF_GetGPUTextDrawData()` data).
The bottom right of each glyph was seemingly not expanded to include the spread, shrinking each visible character.

Without SDF:
<img width="464" height="123" alt="image" src="https://github.com/user-attachments/assets/548cc871-e3ea-4fc1-9a78-629426fa1ba6" />

With SDF:
<img width="464" height="123" alt="image" src="https://github.com/user-attachments/assets/f18f498b-f5a5-4d76-a3d1-c6b970213cc1" />

This change corrects that, bringing SDF back in line:
<img width="464" height="123" alt="image" src="https://github.com/user-attachments/assets/12f45751-eabe-47c6-a33a-b433b066e3ae" />

I haven't tested this with other rendering modes and setups (so it will need a sanity check)
But at a glance it looked like an incorrect typo (why would we be shrinking the dest rects?), and sure enough removing those 2 lines fixed alignment for me. So.. probably all good :P