### PR TITLE
added: TTF_GetFontCapHeight() and TTF_GetFontXHeight()

### DIFF
--- a/include/SDL3_ttf/SDL_ttf.h
+++ b/include/SDL3_ttf/SDL_ttf.h
@@ -778,6 +778,40 @@ extern SDL_DECLSPEC int SDLCALL TTF_GetFontAscent(const TTF_Font *font);
 extern SDL_DECLSPEC int SDLCALL TTF_GetFontDescent(const TTF_Font *font);
 
 /**
+ * Query the cap height of a font
+ * 
+ * This is the approximate height of a capital letter, from the baseline to the
+ * top of the flat.
+ *
+ * This is a positive value, relative to the baseline.
+ *
+ * \param font the font to query.
+ * \returns the font's cap height.
+ *
+ * \threadsafety It is safe to call this function from any thread.
+ *
+ * \since This function is available since SDL_ttf 3.0.0.
+ */
+extern SDL_DECLSPEC int SDLCALL TTF_GetFontCapHeight(const TTF_Font *font);
+
+/**
+ * Query the x-height of a font
+ * 
+ * This is the approximate height of a lowercase letter (or 'x'), from the
+ * baseline to the top of the flat.
+ *
+ * This is a positive value, relative to the baseline.
+ *
+ * \param font the font to query.
+ * \returns the font's x-height.
+ *
+ * \threadsafety It is safe to call this function from any thread.
+ *
+ * \since This function is available since SDL_ttf 3.0.0.
+ */
+extern SDL_DECLSPEC int SDLCALL TTF_GetFontXHeight(const TTF_Font *font);
+
+/**
  * Set the spacing between lines of text for a font.
  *
  * This updates any TTF_Text objects using this font.

--- a/src/SDL_ttf.c
+++ b/src/SDL_ttf.c
@@ -2387,7 +2387,7 @@ static void TTF_InitFontMetrics(TTF_Font *font)
     FT_Face face = font->face;
     int underline_offset;
 
-    // Retrieve the weight from the OS2 TrueType table
+    // Retrieve the additional OS2 TrueType table for extra info
     const TT_OS2 *os2_table = (const TT_OS2 *)FT_Get_Sfnt_Table(face, FT_SFNT_OS2);
 
     // Make sure that our font face is scalable (global metrics)

--- a/src/SDL_ttf.c
+++ b/src/SDL_ttf.c
@@ -2397,7 +2397,7 @@ static void TTF_InitFontMetrics(TTF_Font *font)
         font->ascent         = FT_CEIL(FT_MulFix(face->ascender, scale));
         font->descent        = FT_CEIL(FT_MulFix(face->descender, scale));
         font->capheight      = os2_table && os2_table->version >= 2 ? FT_CEIL(FT_MulFix(os2_table->sCapHeight, scale)) : font->ascent;
-        font->xheight        = os2_table && os2_table->version >= 2 ? FT_CEIL(FT_MulFix(os2_table->sxHeight, scale)) : font->ascent * 2 / 3;
+        font->xheight        = os2_table && os2_table->version >= 2 ? FT_CEIL(FT_MulFix(os2_table->sxHeight, scale)) : font->ascent * 3 / 5;
         font->height         = FT_CEIL(FT_MulFix(face->ascender - face->descender, scale));
         font->lineskip       = FT_CEIL(FT_MulFix(face->height, scale));
         underline_offset     = FT_FLOOR(FT_MulFix(face->underline_position, scale));
@@ -2407,7 +2407,7 @@ static void TTF_InitFontMetrics(TTF_Font *font)
         font->ascent         = FT_CEIL(face->size->metrics.ascender);
         font->descent        = FT_CEIL(face->size->metrics.descender);
         font->capheight      = os2_table && os2_table->version >= 2 ? FT_CEIL(os2_table->sCapHeight) : font->ascent;
-        font->xheight        = os2_table && os2_table->version >= 2 ? FT_CEIL(os2_table->sxHeight) : font->ascent * 2 / 3;
+        font->xheight        = os2_table && os2_table->version >= 2 ? FT_CEIL(os2_table->sxHeight) : font->ascent * 3 / 5;
         font->height         = FT_CEIL(face->size->metrics.height);
         font->lineskip       = FT_CEIL(face->size->metrics.height);
         /* face->underline_position and face->underline_height are only

--- a/src/SDL_ttf.c
+++ b/src/SDL_ttf.c
@@ -295,6 +295,8 @@ struct TTF_Font {
     int height;
     int ascent;
     int descent;
+    int capheight;
+    int xheight;
     int lineskip;
 
     // The font style
@@ -2385,12 +2387,17 @@ static void TTF_InitFontMetrics(TTF_Font *font)
     FT_Face face = font->face;
     int underline_offset;
 
+    // Retrieve the weight from the OS2 TrueType table
+    const TT_OS2 *os2_table = (const TT_OS2 *)FT_Get_Sfnt_Table(face, FT_SFNT_OS2);
+
     // Make sure that our font face is scalable (global metrics)
     if (FT_IS_SCALABLE(face)) {
         // Get the scalable font metrics for this font
         FT_Fixed scale       = face->size->metrics.y_scale;
         font->ascent         = FT_CEIL(FT_MulFix(face->ascender, scale));
         font->descent        = FT_CEIL(FT_MulFix(face->descender, scale));
+        font->capheight      = os2_table && os2_table->version >= 2 ? FT_CEIL(FT_MulFix(os2_table->sCapHeight, scale)) : font->ascent;
+        font->xheight        = os2_table && os2_table->version >= 2 ? FT_CEIL(FT_MulFix(os2_table->sxHeight, scale)) : font->ascent * 2 / 3;
         font->height         = FT_CEIL(FT_MulFix(face->ascender - face->descender, scale));
         font->lineskip       = FT_CEIL(FT_MulFix(face->height, scale));
         underline_offset     = FT_FLOOR(FT_MulFix(face->underline_position, scale));
@@ -2399,6 +2406,8 @@ static void TTF_InitFontMetrics(TTF_Font *font)
         // Get the font metrics for this font, for the selected size
         font->ascent         = FT_CEIL(face->size->metrics.ascender);
         font->descent        = FT_CEIL(face->size->metrics.descender);
+        font->capheight      = os2_table && os2_table->version >= 2 ? FT_CEIL(os2_table->sCapHeight) : font->ascent;
+        font->xheight        = os2_table && os2_table->version >= 2 ? FT_CEIL(os2_table->sxHeight) : font->ascent * 2 / 3;
         font->height         = FT_CEIL(face->size->metrics.height);
         font->lineskip       = FT_CEIL(face->size->metrics.height);
         /* face->underline_position and face->underline_height are only
@@ -5861,6 +5870,20 @@ int TTF_GetFontDescent(const TTF_Font *font)
     TTF_CHECK_FONT(font, 0);
 
     return font->descent;
+}
+
+int TTF_GetFontCapHeight(const TTF_Font *font)
+{
+    TTF_CHECK_FONT(font, 0);
+
+    return font->capheight;
+}
+
+int TTF_GetFontXHeight(const TTF_Font *font)
+{
+    TTF_CHECK_FONT(font, 0);
+
+    return font->xheight;
 }
 
 void TTF_SetFontLineSkip(TTF_Font *font, int lineskip)

--- a/src/SDL_ttf.exports
+++ b/src/SDL_ttf.exports
@@ -21,6 +21,7 @@ _TTF_FontHasGlyph
 _TTF_FontIsFixedWidth
 _TTF_FontIsScalable
 _TTF_GetFontAscent
+_TTF_GetFontCapHeight
 _TTF_GetFontDPI
 _TTF_GetFontDescent
 _TTF_GetFontDirection
@@ -39,6 +40,7 @@ _TTF_GetFontStyle
 _TTF_GetFontStyleName
 _TTF_GetFontWeight
 _TTF_GetFontWrapAlignment
+_TTF_GetFontXHeight
 _TTF_GetFreeTypeVersion
 _TTF_GetGlyphImage
 _TTF_GetGlyphImageForIndex

--- a/src/SDL_ttf.sym
+++ b/src/SDL_ttf.sym
@@ -22,6 +22,7 @@ SDL3_ttf_0.0.0 {
     TTF_FontIsFixedWidth;
     TTF_FontIsScalable;
     TTF_GetFontAscent;
+    TTF_GetFontCapHeight;
     TTF_GetFontDPI;
     TTF_GetFontDescent;
     TTF_GetFontDirection;
@@ -40,6 +41,7 @@ SDL3_ttf_0.0.0 {
     TTF_GetFontStyleName;
     TTF_GetFontWeight;
     TTF_GetFontWrapAlignment;
+    TTF_GetFontXHeight;
     TTF_GetFreeTypeVersion;
     TTF_GetGlyphImage;
     TTF_GetGlyphImageForIndex;


### PR DESCRIPTION
When it comes to aligning text, it helps to know the standard height of letters.

This isn't quite the same as the ascent, as that tends to include extra space above characters for accents and things.

So this adds the ability to query the cap and x-height of letters (the standard "approximate" height of upper and lowercase characters)

If this info isn't available then it falls back to being the ascent value and 3/5ths of that for lowercase.
(I've no idea if 3/5ths is a good approximation but it looked about right, so seemed reasonable)