### PR TITLE
PSP: Fix crash when rendering solid, shaded or lcd text

### DIFF
--- a/SDL_ttf.c
+++ b/SDL_ttf.c
@@ -139,6 +139,12 @@ int TTF_SetScript(int script) /* hb_script_t */
 /* Default: round glyph width to 4 bytes to copy them faster */
 #define HAVE_BLIT_GLYPH_32
 
+// The Playstation Portable doesn't work with either HAVE_BLIT_GLYPH setting
+#if defined (__PSP__)
+#    undef HAVE_BLIT_GLYPH_64
+#    undef HAVE_BLIT_GLYPH_32
+#endif
+
 /* Use Duff's device to unroll loops */
 //#define USE_DUFFS_LOOP
 


### PR DESCRIPTION
On the Playstation Portable rendering text in any mode other than blended crashes the application. This only affects SDL2_ttf. It seems to be fixed in the SDL3 version. This bug has been around for a while [here](https://github.com/pspdev/psp-packages/issues/45), but it wasn't until recently that @isage found the fix that is found within this PR.