### PR TITLE
OpenType variable font axis API

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -579,6 +579,7 @@ if(SDLTTF_SAMPLES)
     add_sdl_ttf_example_executable(testapp examples/testapp.c)
     add_sdl_ttf_example_executable(testgputext examples/testgputext.c)
     add_sdl_ttf_example_executable(testgltext examples/testgltext.c)
+    add_sdl_ttf_example_executable(variablefont examples/variablefont.c)
 
     set(OpenGL_GL_PREFERENCE GLVND)
     find_package(OpenGL)

--- a/examples/variablefont.c
+++ b/examples/variablefont.c
@@ -1,0 +1,112 @@
+/*
+  Copyright (C) 1997-2026 Sam Lantinga <slouken@libsdl.org>
+
+  This software is provided 'as-is', without any express or implied
+  warranty.  In no event will the authors be held liable for any damages
+  arising from the use of this software.
+
+  Permission is granted to anyone to use this software for any purpose,
+  including commercial applications, and to alter it and redistribute it
+  freely.
+*/
+
+/* Demonstrates the OpenType variable-font axis API:
+ *   - enumerate a font's variation axes
+ *   - print each axis tag, its [min, default, max] range and current value
+ *   - set the 'wght' (weight) axis and render a sample string at that weight
+ *
+ * Usage: variablefont <font.ttf> [ptsize] [wght]
+ */
+#include <SDL3/SDL.h>
+#include <SDL3/SDL_main.h>
+#include <SDL3_ttf/SDL_ttf.h>
+
+int main(int argc, char *argv[])
+{
+    if (argc < 2) {
+        SDL_Log("Usage: %s <font.ttf> [ptsize] [wght]", argv[0]);
+        return 1;
+    }
+
+    const char *font_path = argv[1];
+    float ptsize = (argc > 2) ? (float)SDL_atof(argv[2]) : 48.0f;
+
+    if (!TTF_Init()) {
+        SDL_Log("TTF_Init() failed: %s", SDL_GetError());
+        return 1;
+    }
+
+    TTF_Font *font = TTF_OpenFont(font_path, ptsize);
+    if (!font) {
+        SDL_Log("TTF_OpenFont() failed: %s", SDL_GetError());
+        TTF_Quit();
+        return 1;
+    }
+
+    /* Enumerate the axes and print each tag with its range and current value. */
+    int num_axes = TTF_GetNumFontAxes(font);
+    if (num_axes <= 0) {
+        SDL_Log("'%s' has no variable-font axes (TTF_GetNumFontAxes() returned %d).", font_path, num_axes);
+    } else {
+        SDL_Log("'%s' exposes %d variation axis/axes:", font_path, num_axes);
+        for (int i = 0; i < num_axes; ++i) {
+            TTF_AxisInfo info;
+            char tag[5];
+            float current = 0.0f;
+
+            if (!TTF_GetFontAxisInfo(font, i, &info)) {
+                SDL_Log("  axis %d: TTF_GetFontAxisInfo() failed: %s", i, SDL_GetError());
+                continue;
+            }
+            const char *name = TTF_GetFontAxisName(font, i);
+
+            TTF_TagToString(info.tag, tag, sizeof(tag));
+            TTF_GetFontAxisValue(font, info.tag, &current);
+            SDL_Log("  '%s' (%s): min=%.1f default=%.1f max=%.1f (current=%.1f)%s",
+                    tag, name ? name : "?", info.min_value, info.default_value, info.max_value, current,
+                    (info.flags & TTF_FONT_AXIS_HIDDEN) ? " [hidden]" : "");
+        }
+    }
+
+    /* If the font has a weight axis, push it and render a sample. */
+    Uint32 weight_tag = TTF_StringToTag("wght");
+    TTF_AxisInfo wght;
+    bool has_weight = false;
+    for (int i = 0; i < num_axes; ++i) {
+        if (TTF_GetFontAxisInfo(font, i, &wght) && wght.tag == weight_tag) {
+            has_weight = true;
+            break;
+        }
+    }
+
+    if (has_weight) {
+        float value = (argc > 3) ? (float)SDL_atof(argv[3]) : wght.max_value;
+        SDL_Log("Setting 'wght' to %.1f ...", value);
+        if (!TTF_SetFontAxisValue(font, weight_tag, value)) {
+            SDL_Log("TTF_SetFontAxisValue() failed: %s", SDL_GetError());
+        } else {
+            SDL_Color white = { 255, 255, 255, 255 };
+            SDL_Surface *surface;
+            float now = 0.0f;
+
+            TTF_GetFontAxisValue(font, weight_tag, &now);
+            SDL_Log("'wght' is now %.1f", now);
+
+            /* Render at the new weight and save it, to confirm the axis change
+             * actually reaches the rasteriser. */
+            surface = TTF_RenderText_Blended(font, "Variable 123", 0, white);
+            if (surface) {
+                if (SDL_SaveBMP(surface, "variablefont.bmp")) {
+                    SDL_Log("Wrote variablefont.bmp (%dx%d)", surface->w, surface->h);
+                }
+                SDL_DestroySurface(surface);
+            }
+        }
+    } else {
+        SDL_Log("Font has no 'wght' axis; skipping the weight demo.");
+    }
+
+    TTF_CloseFont(font);
+    TTF_Quit();
+    return 0;
+}

--- a/include/SDL3_ttf/SDL_ttf.h
+++ b/include/SDL3_ttf/SDL_ttf.h
@@ -439,6 +439,140 @@ extern SDL_DECLSPEC float SDLCALL TTF_GetFontSize(TTF_Font *font);
 extern SDL_DECLSPEC bool SDLCALL TTF_GetFontDPI(TTF_Font *font, int *hdpi, int *vdpi);
 
 /**
+ * Information about a single OpenType variable-font axis.
+ *
+ * \since This struct is available since SDL_ttf 3.3.0.
+ *
+ * \sa TTF_GetFontAxisInfo
+ */
+typedef struct TTF_AxisInfo
+{
+    Uint32 tag;          /**< the axis tag; use TTF_TagToString() to read it as text (e.g. "wght") */
+    float min_value;     /**< the minimum value the axis accepts */
+    float default_value; /**< the value the axis takes in the font's default instance */
+    float max_value;     /**< the maximum value the axis accepts */
+    Uint32 flags;        /**< the OpenType 'fvar' axis flags; test against the TTF_FONT_AXIS_* bits */
+} TTF_AxisInfo;
+
+#define TTF_FONT_AXIS_HIDDEN 0x01u /**< the axis is not meant to be exposed in a user interface (OpenType fvar HIDDEN flag) */
+
+/**
+ * Get the number of OpenType variable-font axes in a font.
+ *
+ * Variable fonts expose one or more named axes (such as `'wght'` for weight or
+ * `'wdth'` for width) that can be adjusted with TTF_SetFontAxisValue() to
+ * select an arbitrary instance between the font's masters. Fonts that are not
+ * variable fonts simply report zero axes.
+ *
+ * \param font the font to query.
+ * \returns the number of variation axes, 0 if the font is not a variable font,
+ *          or -1 on failure; call SDL_GetError() for more information.
+ *
+ * \threadsafety This function should be called on the thread that created the
+ *               font.
+ *
+ * \since This function is available since SDL_ttf 3.3.0.
+ *
+ * \sa TTF_GetFontAxisInfo
+ * \sa TTF_SetFontAxisValue
+ */
+extern SDL_DECLSPEC int SDLCALL TTF_GetNumFontAxes(const TTF_Font *font);
+
+/**
+ * Get information about a variable-font axis by index.
+ *
+ * `axis_index` must be in the range [0, TTF_GetNumFontAxes() - 1]. The filled
+ * in TTF_AxisInfo reports the axis tag and its minimum, default, and maximum
+ * values, which are the bounds accepted by TTF_SetFontAxisValue().
+ *
+ * \param font the font to query.
+ * \param axis_index the index of the axis to query.
+ * \param info a pointer filled in with the axis information on success.
+ * \returns true on success or false on failure; call SDL_GetError() for more
+ *          information.
+ *
+ * \threadsafety This function should be called on the thread that created the
+ *               font.
+ *
+ * \since This function is available since SDL_ttf 3.3.0.
+ *
+ * \sa TTF_GetNumFontAxes
+ * \sa TTF_SetFontAxisValue
+ */
+extern SDL_DECLSPEC bool SDLCALL TTF_GetFontAxisInfo(const TTF_Font *font, int axis_index, TTF_AxisInfo *info);
+
+/**
+ * Get the human-readable name of a variable-font axis.
+ *
+ * `axis_index` must be in the range [0, TTF_GetNumFontAxes() - 1]. The returned
+ * string (e.g. "Weight" or "Optical Size") comes from the font's name table,
+ * and is useful for presenting the axis in a UI.
+ *
+ * \param font the font to query.
+ * \param axis_index the index of the axis to query.
+ * \returns the axis name, owned by the font and valid until it is closed, or
+ *          NULL if the axis has no name or on failure; call SDL_GetError() for
+ *          more information.
+ *
+ * \threadsafety This function should be called on the thread that created the
+ *               font.
+ *
+ * \since This function is available since SDL_ttf 3.3.0.
+ *
+ * \sa TTF_GetNumFontAxes
+ * \sa TTF_GetFontAxisInfo
+ */
+extern SDL_DECLSPEC const char * SDLCALL TTF_GetFontAxisName(const TTF_Font *font, int axis_index);
+
+/**
+ * Set the value of a variable-font axis.
+ *
+ * `tag` is a 4-character OpenType axis tag, such as `'wght'` (weight) or
+ * `'wdth'` (width); build one from a string with TTF_StringToTag(), e.g.
+ * `TTF_StringToTag("wght")`. The value is clamped to the axis's [min, max]
+ * range as reported by TTF_GetFontAxisInfo().
+ *
+ * This updates any TTF_Text objects using this font, and clears
+ * already-generated glyphs, if any, from the cache.
+ *
+ * \param font the font to modify.
+ * \param tag the OpenType tag of the axis to set.
+ * \param value the value to set the axis to.
+ * \returns true on success or false on failure (for example, if the font has
+ *          no axis with that tag); call SDL_GetError() for more information.
+ *
+ * \threadsafety This function should be called on the thread that created the
+ *               font.
+ *
+ * \since This function is available since SDL_ttf 3.3.0.
+ *
+ * \sa TTF_GetFontAxisValue
+ * \sa TTF_GetFontAxisInfo
+ * \sa TTF_StringToTag
+ */
+extern SDL_DECLSPEC bool SDLCALL TTF_SetFontAxisValue(TTF_Font *font, Uint32 tag, float value);
+
+/**
+ * Get the current value of a variable-font axis.
+ *
+ * \param font the font to query.
+ * \param tag the OpenType tag of the axis to query; build one with
+ *            TTF_StringToTag() (see TTF_SetFontAxisValue()).
+ * \param value a pointer filled in with the current axis value on success.
+ * \returns true on success or false on failure (for example, if the font has
+ *          no axis with that tag); call SDL_GetError() for more information.
+ *
+ * \threadsafety This function should be called on the thread that created the
+ *               font.
+ *
+ * \since This function is available since SDL_ttf 3.3.0.
+ *
+ * \sa TTF_SetFontAxisValue
+ * \sa TTF_StringToTag
+ */
+extern SDL_DECLSPEC bool SDLCALL TTF_GetFontAxisValue(const TTF_Font *font, Uint32 tag, float *value);
+
+/**
  * Font style flags for TTF_Font
  *
  * These are the flags which can be used to set the style of a font in

--- a/src/SDL_ttf.c
+++ b/src/SDL_ttf.c
@@ -33,6 +33,7 @@
 #include FT_TRUETYPE_IDS_H
 #include FT_TRUETYPE_TABLES_H
 #include FT_IMAGE_H
+#include FT_MULTIPLE_MASTERS_H
 
 // Enable Signed Distance Field rendering (requires latest FreeType version)
 #if defined(FT_RASTER_FLAG_SDF)
@@ -278,6 +279,11 @@ struct TTF_Font {
     // Freetype2 maintains all sorts of useful info itself
     FT_Face face;
     long face_index;
+
+    // Variable font (OpenType 'fvar') axis metadata, queried lazily on the
+    // first axis call; NULL if the font has no variation axes. Freed with
+    // FT_Done_MM_Var in TTF_CloseFont.
+    FT_MM_Var *mm_var;
 
     // Properties exposed to the application
     SDL_PropertiesID props;
@@ -2173,6 +2179,13 @@ TTF_Font *TTF_OpenFontWithProperties(SDL_PropertiesID props)
         } else {
             font->weight = TTF_FONT_WEIGHT_NORMAL;
         }
+    }
+
+    // Cache variable-font ('fvar') axis metadata up front -- NULL for
+    // non-variable fonts -- so the axis query functions can stay const.
+    // Freed with FT_Done_MM_Var in TTF_CloseFont.
+    if (FT_HAS_MULTIPLE_MASTERS(face)) {
+        FT_Get_MM_Var(face, &font->mm_var);
     }
 
 #if TTF_USE_HARFBUZZ
@@ -5631,6 +5644,198 @@ bool TTF_GetFontDPI(TTF_Font *font, int *hdpi, int *vdpi)
     return true;
 }
 
+// Returns the font's variable-axis ('fvar') metadata, queried and cached at
+// open time; NULL (without setting an error) for fonts with no variation axes.
+static FT_MM_Var *GetFontMMVar(const TTF_Font *font)
+{
+    return font->mm_var;
+}
+
+// Find the axis index for a 4-character OpenType tag, e.g. 'wght'.
+static bool FindFontAxis(FT_MM_Var *var, Uint32 tag, FT_UInt *index)
+{
+    for (FT_UInt i = 0; i < var->num_axis; ++i) {
+        if ((Uint32)var->axis[i].tag == tag) {
+            *index = i;
+            return true;
+        }
+    }
+    return false;
+}
+
+int TTF_GetNumFontAxes(const TTF_Font *font)
+{
+    TTF_CHECK_FONT(font, -1);
+
+    FT_MM_Var *var = GetFontMMVar(font);
+    if (!var) {
+        return 0;
+    }
+    return (int)var->num_axis;
+}
+
+bool TTF_GetFontAxisInfo(const TTF_Font *font, int axis_index, TTF_AxisInfo *info)
+{
+    if (info) {
+        SDL_zerop(info);
+    }
+
+    TTF_CHECK_FONT(font, false);
+
+    if (!info) {
+        return SDL_InvalidParamError("info");
+    }
+
+    FT_MM_Var *var = GetFontMMVar(font);
+    if (!var) {
+        return SDL_SetError("Font has no variation axes");
+    }
+    if (axis_index < 0 || (FT_UInt)axis_index >= var->num_axis) {
+        return SDL_InvalidParamError("axis_index");
+    }
+
+    // FreeType reports axis ranges as 16.16 fixed-point design values.
+    const FT_Var_Axis *axis = &var->axis[axis_index];
+    info->tag = (Uint32)axis->tag;
+    info->min_value = (float)(axis->minimum / 65536.0);
+    info->default_value = (float)(axis->def / 65536.0);
+    info->max_value = (float)(axis->maximum / 65536.0);
+
+    // Pass the OpenType 'fvar' axis flags straight through (FreeType returns
+    // them verbatim). The TTF_FONT_AXIS_* constants mirror the spec bit values,
+    // so future flags surface here without an API change.
+    FT_UInt ft_flags = 0;
+    FT_Get_Var_Axis_Flags(var, (FT_UInt)axis_index, &ft_flags);
+    info->flags = (Uint32)ft_flags;
+    return true;
+}
+
+const char *TTF_GetFontAxisName(const TTF_Font *font, int axis_index)
+{
+    TTF_CHECK_FONT(font, NULL);
+
+    FT_MM_Var *var = GetFontMMVar(font);
+    if (!var) {
+        SDL_SetError("Font has no variation axes");
+        return NULL;
+    }
+    if (axis_index < 0 || (FT_UInt)axis_index >= var->num_axis) {
+        SDL_InvalidParamError("axis_index");
+        return NULL;
+    }
+
+    // FreeType owns this string (part of the cached FT_MM_Var); it stays valid
+    // until the font is closed. May be NULL if the axis has no name entry.
+    return var->axis[axis_index].name;
+}
+
+bool TTF_SetFontAxisValue(TTF_Font *font, Uint32 tag, float value)
+{
+    TTF_CHECK_FONT(font, false);
+
+    FT_MM_Var *var = GetFontMMVar(font);
+    if (!var) {
+        return SDL_SetError("Font has no variation axes");
+    }
+
+    FT_UInt index;
+    if (!FindFontAxis(var, tag, &index)) {
+        char tag_string[5];
+        TTF_TagToString(tag, tag_string, sizeof(tag_string));
+        return SDL_SetError("Font has no '%s' variation axis", tag_string);
+    }
+
+    // Clamp to the axis's design range (FreeType clamps internally too; doing
+    // it here keeps a later TTF_GetFontAxisValue() consistent with the value
+    // that was actually applied).
+    FT_Fixed coord = (FT_Fixed)SDL_lround((double)value * 65536.0);
+    if (coord < var->axis[index].minimum) {
+        coord = var->axis[index].minimum;
+    }
+    if (coord > var->axis[index].maximum) {
+        coord = var->axis[index].maximum;
+    }
+
+    FT_Fixed *coords = SDL_stack_alloc(FT_Fixed, var->num_axis);
+    if (!coords) {
+        return SDL_OutOfMemory();
+    }
+
+    FT_Error error = FT_Get_Var_Design_Coordinates(font->face, var->num_axis, coords);
+    if (error) {
+        SDL_stack_free(coords);
+        return TTF_SetFTError("Couldn't get font variation coordinates", error);
+    }
+
+    if (coords[index] == coord) {
+        // No change; leave the caches and text objects untouched.
+        SDL_stack_free(coords);
+        return true;
+    }
+
+    coords[index] = coord;
+    error = FT_Set_Var_Design_Coordinates(font->face, var->num_axis, coords);
+    SDL_stack_free(coords);
+    if (error) {
+        return TTF_SetFTError("Couldn't set font variation coordinates", error);
+    }
+
+    /* Changing an axis reshapes the glyph outlines and, for fonts with an
+     * 'MVAR' table, the global metrics as well. Recompute metrics, drop every
+     * cached glyph/position, and notify text objects and HarfBuzz -- the same
+     * invalidation TTF_SetFontSizeDPI() performs when the size changes. */
+    TTF_InitFontMetrics(font);
+    Flush_Cache(font);
+    UpdateFontText(font, NULL);
+
+#if TTF_USE_HARFBUZZ
+    // Call when size or variations settings on underlying FT_Face change.
+    hb_ft_font_changed(font->hb_font);
+#endif
+
+    return true;
+}
+
+bool TTF_GetFontAxisValue(const TTF_Font *font, Uint32 tag, float *value)
+{
+    if (value) {
+        *value = 0.0f;
+    }
+
+    TTF_CHECK_FONT(font, false);
+
+    if (!value) {
+        return SDL_InvalidParamError("value");
+    }
+
+    FT_MM_Var *var = GetFontMMVar(font);
+    if (!var) {
+        return SDL_SetError("Font has no variation axes");
+    }
+
+    FT_UInt index;
+    if (!FindFontAxis(var, tag, &index)) {
+        char tag_string[5];
+        TTF_TagToString(tag, tag_string, sizeof(tag_string));
+        return SDL_SetError("Font has no '%s' variation axis", tag_string);
+    }
+
+    FT_Fixed *coords = SDL_stack_alloc(FT_Fixed, var->num_axis);
+    if (!coords) {
+        return SDL_OutOfMemory();
+    }
+
+    FT_Error error = FT_Get_Var_Design_Coordinates(font->face, var->num_axis, coords);
+    if (error) {
+        SDL_stack_free(coords);
+        return TTF_SetFTError("Couldn't get font variation coordinates", error);
+    }
+
+    *value = (float)(coords[index] / 65536.0);
+    SDL_stack_free(coords);
+    return true;
+}
+
 void TTF_SetFontStyle(TTF_Font *font, TTF_FontStyleFlags style)
 {
     TTF_FontStyleFlags prev_style;
@@ -6142,6 +6347,9 @@ void TTF_CloseFont(TTF_Font *font)
 #endif
     if (font->props) {
         SDL_DestroyProperties(font->props);
+    }
+    if (font->mm_var) {
+        FT_Done_MM_Var(TTF_state.library, font->mm_var);
     }
     if (font->face) {
         FT_Done_Face(font->face);

--- a/src/SDL_ttf.exports
+++ b/src/SDL_ttf.exports
@@ -124,4 +124,9 @@ _TTF_Version
 _TTF_WasInit
 _TTF_SetFontCharSpacing
 _TTF_GetFontCharSpacing
+_TTF_GetNumFontAxes
+_TTF_GetFontAxisInfo
+_TTF_SetFontAxisValue
+_TTF_GetFontAxisValue
+_TTF_GetFontAxisName
 # extra symbols go here (don't modify this line)

--- a/src/SDL_ttf.sym
+++ b/src/SDL_ttf.sym
@@ -125,6 +125,11 @@ SDL3_ttf_0.0.0 {
     TTF_WasInit;
     TTF_SetFontCharSpacing;
     TTF_GetFontCharSpacing;
+    TTF_GetNumFontAxes;
+    TTF_GetFontAxisInfo;
+    TTF_SetFontAxisValue;
+    TTF_GetFontAxisValue;
+    TTF_GetFontAxisName;
     # extra symbols go here (don't modify this line)
   local: *;
 };


### PR DESCRIPTION
## OpenType variable font axis API

Adds a small API to list a variable font's fvar axes and set their values at runtime. 
SDL_ttf can open variable fonts but has no way to drive the axes, so apps that want a specific weight/width/optical-size (or to animate Material Symbols's FILL/wght/GRAD/opsz) currently have to bypass SDL_ttf and call FreeType on the face directly.

### Example
```c
// Api
typedef struct TTF_AxisInfo {
    Uint32 tag;
    float  min_value, default_value, max_value;
    Uint32 flags;
} TTF_AxisInfo;

int TTF_GetNumFontAxes (const TTF_Font *font);
bool TTF_GetFontAxisInfo(const TTF_Font *font, int axis_index, TTF_AxisInfo *info);
const char *TTF_GetFontAxisName(const TTF_Font *font, int axis_index);
bool TTF_SetFontAxisValue(TTF_Font *font, Uint32 tag, float value);
bool TTF_GetFontAxisValue(const TTF_Font *font, Uint32 tag, float *value);
```
```c
// example
for (int i = 0, n = TTF_GetNumFontAxes(font); i < n; ++i) {
    TTF_AxisInfo a;
    if (TTF_GetFontAxisInfo(font, i, &a)) {
        char tag[5]; TTF_TagToString(a.tag, tag, sizeof(tag));
        SDL_Log("%s (%s): %.0f..%.0f", tag, TTF_GetFontAxisName(font, i), a.min_value, a.max_value);
    }
}

TTF_SetFontAxisValue(font, TTF_StringToTag("wght"), 700.0f);
```

### Notes

- Wraps FreeType FT_Get_MM_Var / FT_Get_Var_Design_Coordinates / FT_Set_Var_Design_Coordinates / FT_Get_Var_Axis_Flags. Works with or without HarfBuzz.
- FT_MM_Var is queried once at open and cached on the font (so the getters are const), and freed with FT_Done_MM_Var in TTF_CloseFont.
- Setting an axis reuses the TTF_SetFontSizeDPI invalidation path (TTF_InitFontMetrics, Flush_Cache, UpdateFontText, hb_ft_font_changed).
- flags passes the raw fvar flags through, so future flags need no API change; only TTF_FONT_AXIS_HIDDEN is named.
- Tags use the existing TTF_StringToTag/TTF_TagToString. Fonts with no axes report 0 and behave as before.

### Testing

Builds with -Werror. Added examples/variablefont.c; tested with Material Symbols and a variable Roboto: axis ranges and names read correctly and wght 100 to 900 changes the rendered text. 
Re-ran genexports.py.

<img width="1245" height="836" alt="roboto_weight" src="https://github.com/user-attachments/assets/fb1d36f8-c9dd-486b-a152-c85b2059d75d" />

<img width="1403" height="526" alt="noto_weight_width" src="https://github.com/user-attachments/assets/a0f0766e-f9d4-4643-9630-21eba8b4f05e" />



<img width="1288" height="1062" alt="fill" src="https://github.com/user-attachments/assets/72e85cbc-9235-4448-be55-aed31432bcf8" />

<img width="1288" height="1062" alt="weight" src="https://github.com/user-attachments/assets/44247875-2aed-477d-ab0e-ec853a726990" />
