### PR TITLE
remove extra call to TTF_SetFTError

### DIFF
--- a/src/SDL_ttf.c
+++ b/src/SDL_ttf.c
@@ -2192,7 +2192,6 @@ TTF_Font *TTF_OpenFontWithProperties(SDL_PropertiesID props)
 #endif
 
     if (!TTF_SetFontSizeDPI(font, ptsize, hdpi, vdpi)) {
-        TTF_SetFTError("Couldn't set font size", error);
         TTF_CloseFont(font);
         return NULL;
     }


### PR DESCRIPTION
TTF_SetFontSizeDPI has already set the error, and besides, the `error` variable is 0 here and the actual error from TTF_SetFontSizeDPI was being overwritten.